### PR TITLE
[DS-34]사장님 회원가입 Requset DTO 추가

### DIFF
--- a/src/main/java/com/dangol/dangolsonnimbackend/boss/dto/BossSignupRequestDTO.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/boss/dto/BossSignupRequestDTO.java
@@ -1,0 +1,47 @@
+package com.dangol.dangolsonnimbackend.boss.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BossSignupRequestDTO {
+
+    @NotNull(message = "이름은 Null 일 수 없습니다.")
+    @Size(min = 1, max = 10, message = "이름은 1 ~ 8자 이여야 합니다.")
+    private String name;
+
+    @NotNull(message = "휴대폰 번호는 Null 일 수 없습니다.")
+    @Size(min = 11, max = 11, message = "휴대폰 번호는 11자 이여야 합니다.")
+    private String bossPhoneNumber;
+
+    @NotNull(message = "이메일은 Null 일 수 없습니다.")
+    @Email
+    private String email;
+
+    @NotNull
+    @Size(min = 8, message = "비밀번호는 8자 이상이여야 합니다.")
+    private String password;
+
+    @NotNull(message = "사업자 번호는 Null 일 수 없습니다.")
+    private String storeRegisterNumber;
+
+    @NotNull(message = "가게 이름은 Null 일 수 없습니다.")
+    private String storeRegisterName;
+
+    @NotNull(message = "마케팅 수신 정보 동의는 Null 일 수 없습니다.")
+    private Boolean marketingAgreement;
+
+    public void passwordEncode(String encodedPassword){
+        this.password = encodedPassword;
+    }
+}

--- a/src/main/java/com/dangol/dangolsonnimbackend/boss/dto/BossSignupRequestDTO.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/boss/dto/BossSignupRequestDTO.java
@@ -12,8 +12,6 @@ import javax.validation.constraints.Size;
 
 @Getter
 @Setter
-@NoArgsConstructor
-@AllArgsConstructor
 public class BossSignupRequestDTO {
 
     @NotNull(message = "이름은 Null 일 수 없습니다.")


### PR DESCRIPTION
## Goals
- BossSignupRequestDTO라는 새 클래스를 추가하여 사장님 회원 가입 프로세스의 데이터 전송 개체 역할을 한다.

## Implements
- [x] DTO 각 필드에 유효성 체크 및 사이즈 검사 기능이 포함된 어노테이션 추가
- [x] 클래스에 각 필드에 대한 getter 및 setter 어노테이션 추가
- [x] Password가 데이터베이스에 저장되기 전에 암호를 인코딩하는 매서드 추가

## Related Issue 
- https://dangol-sonnim.atlassian.net/browse/DS-34?atlOrigin=eyJpIjoiZDE1MzUyMDNmMjAzNGVjMzlkM2I4ZmY5M2M0YjMxZjUiLCJwIjoiaiJ9

## Notes
해당 브랜치는 DS-32-add-query-dsl 브랜치를 기반으로 작성되었습니다.