### PR TITLE
[DS-39]사장님 회원가입 관련 Service 추가(재 업로드)

### DIFF
--- a/src/main/java/com/dangol/dangolsonnimbackend/boss/repository/dsl/BossQueryRepository.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/boss/repository/dsl/BossQueryRepository.java
@@ -1,5 +1,6 @@
 package com.dangol.dangolsonnimbackend.boss.repository.dsl;
 
+import com.dangol.dangolsonnimbackend.boss.domain.Boss;
 import com.dangol.dangolsonnimbackend.boss.domain.QBoss;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -36,5 +37,11 @@ public class BossQueryRepository {
                 .fetchFirst();
 
         return fetchOne != null;
+    }
+
+    public Boss findByEmail(String email){
+        return queryFactory.selectFrom(QBoss.boss)
+                .where(QBoss.boss.email.eq(email))
+                .fetchOne();
     }
 }

--- a/src/main/java/com/dangol/dangolsonnimbackend/boss/service/BossService.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/boss/service/BossService.java
@@ -1,0 +1,8 @@
+package com.dangol.dangolsonnimbackend.boss.service;
+
+import com.dangol.dangolsonnimbackend.boss.dto.BossSignupRequestDTO;
+
+public interface BossService {
+
+    void signup(BossSignupRequestDTO dto);
+}

--- a/src/main/java/com/dangol/dangolsonnimbackend/boss/service/impl/BossServiceImpl.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/boss/service/impl/BossServiceImpl.java
@@ -1,0 +1,43 @@
+package com.dangol.dangolsonnimbackend.boss.service.impl;
+
+import com.dangol.dangolsonnimbackend.boss.domain.Boss;
+import com.dangol.dangolsonnimbackend.boss.dto.BossSignupRequestDTO;
+import com.dangol.dangolsonnimbackend.boss.repository.BossRepository;
+import com.dangol.dangolsonnimbackend.boss.repository.dsl.BossQueryRepository;
+import com.dangol.dangolsonnimbackend.boss.service.BossService;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+
+@Service
+public class BossServiceImpl implements BossService {
+
+    private final BossRepository bossRepository;
+    private final BossQueryRepository bossQueryRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public BossServiceImpl(BossRepository bossRepository, BossQueryRepository bossQueryRepository,
+                           PasswordEncoder passwordEncoder){
+        this.bossRepository = bossRepository;
+        this.bossQueryRepository = bossQueryRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @Transactional
+    public void signup(BossSignupRequestDTO dto){
+        validateSignup(dto);
+
+        dto.passwordEncode(passwordEncoder.encode(dto.getPassword()));
+        bossRepository.save(new Boss(dto));
+    }
+
+    private void validateSignup(BossSignupRequestDTO dto) {
+        if (bossQueryRepository.existsBySrn(dto.getStoreRegisterName())) {
+            throw new RuntimeException();
+        }
+        if (bossQueryRepository.existsByEmail(dto.getEmail())) {
+            throw new RuntimeException();
+        }
+    }
+}

--- a/src/main/java/com/dangol/dangolsonnimbackend/config/SecurityConfig.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/config/SecurityConfig.java
@@ -1,0 +1,14 @@
+package com.dangol.dangolsonnimbackend.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/test/java/com/dangol/dangolsonnimbackend/boss/repository/BossRepositoryTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/boss/repository/BossRepositoryTest.java
@@ -35,7 +35,7 @@ class BossRepositoryTest {
     }
 
     @Test
-    void whenFindById_thenReturnBoss() {
+    void givenSignupDto_whenFindById_thenReturnBoss() {
         Boss boss = new Boss(dto);
         boss = bossRepository.save(boss);
 
@@ -45,7 +45,7 @@ class BossRepositoryTest {
     }
 
     @Test
-    void whenSaveBoss_thenReturnBoss() {
+    void givenSignupDto_whenSaveBoss_thenReturnBoss() {
         Boss boss = new Boss(dto);
         Boss savedBoss = bossRepository.save(boss);
 

--- a/src/test/java/com/dangol/dangolsonnimbackend/boss/repository/dsl/BossQueryRepositoryTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/boss/repository/dsl/BossQueryRepositoryTest.java
@@ -11,6 +11,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import javax.transaction.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @Transactional
 @SpringBootTest
@@ -100,5 +101,16 @@ class BossQueryRepositoryTest {
 
         // then
         assertThat(result).isFalse();
+    }
+
+    @Test
+    void givenSignupDto_whenFindByEmail_thenReturnBoss() {
+        // given
+
+        // when
+        Boss boss = bossQueryRepository.findByEmail("test@test.com");
+
+        // then
+        assertNotNull(boss);
     }
 }

--- a/src/test/java/com/dangol/dangolsonnimbackend/boss/service/impl/BossServiceImplTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/boss/service/impl/BossServiceImplTest.java
@@ -49,7 +49,6 @@ public class BossServiceImplTest {
     @Test
     public void givenValidDto_whenSignup_thenSaveBoss() {
         // given
-        // validDto set up in beforeEach method
 
         // when
         bossService.signup(validDto);

--- a/src/test/java/com/dangol/dangolsonnimbackend/boss/service/impl/BossServiceImplTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/boss/service/impl/BossServiceImplTest.java
@@ -1,0 +1,95 @@
+package com.dangol.dangolsonnimbackend.boss.service.impl;
+
+import com.dangol.dangolsonnimbackend.boss.domain.Boss;
+import com.dangol.dangolsonnimbackend.boss.dto.BossSignupRequestDTO;
+import com.dangol.dangolsonnimbackend.boss.repository.BossRepository;
+import com.dangol.dangolsonnimbackend.boss.repository.dsl.BossQueryRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import javax.transaction.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+public class BossServiceImplTest {
+
+    @Autowired
+    private BossRepository bossRepository;
+
+    @Autowired
+    private BossQueryRepository bossQueryRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private BossServiceImpl bossService;
+
+    private BossSignupRequestDTO validDto;
+
+    @BeforeEach
+    public void setup() {
+        validDto = new BossSignupRequestDTO();
+
+        validDto.setName("Test");
+        validDto.setPassword("password");
+        validDto.setEmail("test@test.com");
+        validDto.setBossPhoneNumber("01012345678");
+        validDto.setStoreRegisterNumber("1234567890");
+        validDto.setStoreRegisterName("Test Store");
+        validDto.setMarketingAgreement(true);
+
+    }
+
+    @Test
+    public void givenValidDto_whenSignup_thenSaveBoss() {
+        // given
+        // validDto set up in beforeEach method
+
+        // when
+        bossService.signup(validDto);
+
+        // then
+        Boss boss = bossQueryRepository.findByEmail(validDto.getEmail());
+        assertNotNull(boss);
+        assertBossEqualsDto(boss, validDto);
+    }
+
+    @Test
+    public void givenSignup_whenDuplicateSrn_thenThrowException() {
+        // given
+        bossRepository.save(new Boss(validDto));
+
+        // when, then
+        assertThrows(RuntimeException.class, () -> bossService.signup(validDto));
+    }
+
+    @Test
+    public void givenSignup_whenDuplicateEmail_thenThrowException() {
+        // given
+        BossSignupRequestDTO dtoWithDuplicateEmail = new BossSignupRequestDTO();
+
+        dtoWithDuplicateEmail.setName("Test");
+        dtoWithDuplicateEmail.setPassword("password");
+        dtoWithDuplicateEmail.setEmail(validDto.getEmail());
+        dtoWithDuplicateEmail.setBossPhoneNumber("010123");
+        dtoWithDuplicateEmail.setStoreRegisterNumber("12345");
+        dtoWithDuplicateEmail.setStoreRegisterName("Test Store");
+        dtoWithDuplicateEmail.setMarketingAgreement(true);
+        bossRepository.save(new Boss(dtoWithDuplicateEmail));
+
+        // when, then
+        assertThrows(RuntimeException.class, () -> bossService.signup(dtoWithDuplicateEmail));
+    }
+
+    private void assertBossEqualsDto(Boss boss, BossSignupRequestDTO dto) {
+        assertEquals(dto.getEmail(), boss.getEmail());
+        assertTrue(passwordEncoder.matches("password", boss.getPassword()));
+        assertEquals(dto.getStoreRegisterName(), boss.getStoreRegisterName());
+    }
+}


### PR DESCRIPTION
## Goals
- 사장님 회원가입을 위한 비즈니스 로직을 구현합니다

## Implements
- [x] validateSignup 매서드를 추가하여 존재하는 데이터가 있으면 런타임 Exception을 throw 한다.
- [x] 중복검사에 통과하면 Entity를 영속성 컨텍스트에 영속화 시킨다.
- [x] BDD 패턴으로 위 코드를 테스트한다 

## Related Issue 
- https://dangol-sonnim.atlassian.net/browse/DS-39?atlOrigin=eyJpIjoiMmU3ZjVjNmYxY2ExNGRkYzgwMGMwZmM0OTM4MmY2ODciLCJwIjoiaiJ9

## Notes
해당 브랜치는 [feature/DS-36-...] 브랜치를 기반으로 작성되었습니다.
