### PR TITLE
DS-49 [가게] Repository 클래스 설계 및 정의

### DIFF
--- a/src/main/java/com/dangol/dangolsonnimbackend/store/domain/Store.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/store/domain/Store.java
@@ -69,5 +69,6 @@ public class Store {
         this.detailedAddress = dto.getDetailedAddress();
         this.comments = dto.getComments();
         this.officeHours = dto.getOfficeHours();
+        this.categoryId = dto.getCategoryId();
     }
 }

--- a/src/main/java/com/dangol/dangolsonnimbackend/store/domain/Store.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/store/domain/Store.java
@@ -71,4 +71,8 @@ public class Store {
         this.officeHours = dto.getOfficeHours();
         this.categoryId = dto.getCategoryId();
     }
+
+    public void updateName(String name) {
+        this.name = name;
+    }
 }

--- a/src/main/java/com/dangol/dangolsonnimbackend/store/dto/StoreSignupRequestDTO.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/store/dto/StoreSignupRequestDTO.java
@@ -1,12 +1,14 @@
 package com.dangol.dangolsonnimbackend.store.dto;
 
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 import javax.validation.constraints.NotNull;
 
 @Getter
 @Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class StoreSignupRequestDTO {
     @NotNull(message = "이름은 Null 일 수 없습니다.")
     private String name;

--- a/src/main/java/com/dangol/dangolsonnimbackend/store/dto/StoreSignupRequestDTO.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/store/dto/StoreSignupRequestDTO.java
@@ -34,4 +34,7 @@ public class StoreSignupRequestDTO {
 
     @NotNull(message = "영업시간은 Null 일 수 없습니다.")
     private String officeHours;
+
+    @NotNull
+    private Long categoryId;
 }

--- a/src/main/java/com/dangol/dangolsonnimbackend/store/repository/StoreRepository.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/store/repository/StoreRepository.java
@@ -1,0 +1,8 @@
+package com.dangol.dangolsonnimbackend.store.repository;
+
+import com.dangol.dangolsonnimbackend.store.domain.Store;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StoreRepository extends JpaRepository<Store, Long> {
+    // not implemented
+}

--- a/src/main/java/com/dangol/dangolsonnimbackend/store/repository/dsl/StoreQueryRepository.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/store/repository/dsl/StoreQueryRepository.java
@@ -1,0 +1,14 @@
+package com.dangol.dangolsonnimbackend.store.repository.dsl;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class StoreQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    // TODO. 중복체크 및 조회용 인터페이스 설계 필요 시 구현
+}

--- a/src/test/java/com/dangol/dangolsonnimbackend/store/repository/StoreRepositoryTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/store/repository/StoreRepositoryTest.java
@@ -1,0 +1,85 @@
+package com.dangol.dangolsonnimbackend.store.repository;
+
+import com.dangol.dangolsonnimbackend.store.domain.Store;
+import com.dangol.dangolsonnimbackend.store.dto.StoreSignupRequestDTO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import javax.transaction.Transactional;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class StoreRepositoryTest {
+    @Autowired
+    StoreRepository storeRepository;
+
+    StoreSignupRequestDTO dto;
+
+    @BeforeEach
+    void setUp() {
+        dto = StoreSignupRequestDTO.builder()
+                .name("단골손님")
+                .storePhoneNumber("01012345678")
+                .newAddress("서울특별시 서초구 단골로 130")
+                .sido("서울특별시")
+                .sigungu("서초구")
+                .bname1("단골동")
+                .bname2("")
+                .detailedAddress("")
+                .comments("단골손님 가게로 좋아요.")
+                .officeHours("08:00~10:00")
+                .categoryId(1L)
+                .build();
+    }
+
+    @Test
+    @DisplayName("ID 값을 조회하여 가게를 조회한다.")
+    void whenFindById_thenReturnStore() {
+        Store store = new Store(dto);
+        store = storeRepository.save(store);
+
+        Optional<Store> found = storeRepository.findById(store.getId());
+
+        assertTrue(found.isPresent());
+        assertEquals(store, found.get());
+    }
+
+    @Test
+    @DisplayName("ID 값을 조회하여 가게를 수정한다.")
+    void whenFindById_thenUpdateAndCheckStore() {
+        Store store = new Store(dto);
+        store = storeRepository.save(store);
+        Store updatedStore = null;
+
+        Optional<Store> found = storeRepository.findById(store.getId());
+
+        if(found.isPresent()) {
+            store.updateName("그냥손님");
+            updatedStore = storeRepository.save(store);
+        }
+
+        assertEquals(updatedStore.getName(), "그냥손님");
+    }
+
+    @Test
+    @DisplayName("ID 값을 조회하여 가게를 삭제한다.")
+    void whenFindById_thenDeleteStore() {
+        Store store = new Store(dto);
+        store = storeRepository.save(store);
+
+        Optional<Store> found = storeRepository.findById(store.getId());
+
+        if(found.isPresent()) {
+            store.updateName("그냥손님");
+            storeRepository.delete(store);
+        }
+
+        assertFalse(storeRepository.findById(store.getId()).isPresent());
+    }
+}


### PR DESCRIPTION
## Goals
- 가게 정보를 생성/수정/삭제 할 수 있는 Repository 클래스를 설계 및 정의한다.

## Implements
- [x] 가게 Repository 클래스 정의
- [x] 가게 엔티티에서 누락된 필드 추가
- [x] 가게 Repository 클래스 기능 테스트  

## Related Issue 
- https://dangol-sonnim.atlassian.net/browse/DS-49

## Test
- "ID 값을 조회하여 가게를 조회한다."
- "ID 값을 조회하여 가게를 수정한다."
- "ID 값을 조회하여 가게를 삭제한다."