### PR TITLE
DS-49 [가게] Repository 클래스 설계 및 정의

### DIFF
--- a/src/main/java/com/dangol/dangolsonnimbackend/store/repository/StoreRepository.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/store/repository/StoreRepository.java
@@ -1,0 +1,8 @@
+package com.dangol.dangolsonnimbackend.store.repository;
+
+import com.dangol.dangolsonnimbackend.store.domain.Store;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StoreRepository extends JpaRepository<Store, Long> {
+    // not implemented
+}

--- a/src/main/java/com/dangol/dangolsonnimbackend/store/repository/dsl/StoreQueryRepository.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/store/repository/dsl/StoreQueryRepository.java
@@ -1,0 +1,29 @@
+package com.dangol.dangolsonnimbackend.store.repository.dsl;
+
+import com.dangol.dangolsonnimbackend.boss.domain.QBoss;
+import com.dangol.dangolsonnimbackend.store.domain.QStore;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class StoreQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    /**
+     * 가게 사업자 번호에 대한 중복 체크를 한다.
+     *
+     * @param registerNumber 사업자 번호
+     * @return ture or flase
+     */
+    public boolean existsBySrn(String registerNumber) {
+        Integer fetchOne = queryFactory.selectOne()
+                .from(QStore.store)
+                .where(QStore.store.storeRegisterNumber.eq(registerNumber))
+                .fetchFirst();
+
+        return fetchOne != null;
+    }
+}

--- a/src/main/java/com/dangol/dangolsonnimbackend/store/repository/dsl/StoreQueryRepository.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/store/repository/dsl/StoreQueryRepository.java
@@ -1,6 +1,5 @@
 package com.dangol.dangolsonnimbackend.store.repository.dsl;
 
-import com.dangol.dangolsonnimbackend.boss.domain.QBoss;
 import com.dangol.dangolsonnimbackend.store.domain.QStore;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -16,9 +15,9 @@ public class StoreQueryRepository {
      * 가게 사업자 번호에 대한 중복 체크를 한다.
      *
      * @param registerNumber 사업자 번호
-     * @return ture or flase
+     * @return ture or false
      */
-    public boolean existsBySrn(String registerNumber) {
+    public boolean existsByRegisterNumber(String registerNumber) {
         Integer fetchOne = queryFactory.selectOne()
                 .from(QStore.store)
                 .where(QStore.store.storeRegisterNumber.eq(registerNumber))

--- a/src/test/java/com/dangol/dangolsonnimbackend/store/repository/StoreRepositoryTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/store/repository/StoreRepositoryTest.java
@@ -20,11 +20,11 @@ import static org.junit.jupiter.api.Assertions.*;
 @Transactional
 class StoreRepositoryTest {
     @Autowired
-    StoreRepository storeRepository;
+    private StoreRepository storeRepository;
 
-    Store store;
+    private Store store;
 
-    StoreSignupRequestDTO dto;
+    private StoreSignupRequestDTO dto;
 
     @BeforeEach
     void setUp() {

--- a/src/test/java/com/dangol/dangolsonnimbackend/store/repository/StoreRepositoryTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/store/repository/StoreRepositoryTest.java
@@ -1,0 +1,84 @@
+package com.dangol.dangolsonnimbackend.store.repository;
+
+import com.dangol.dangolsonnimbackend.store.domain.Store;
+import com.dangol.dangolsonnimbackend.store.dto.StoreSignupRequestDTO;
+import com.dangol.dangolsonnimbackend.store.repository.dsl.StoreQueryRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import javax.transaction.Transactional;
+import java.util.Optional;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class StoreRepositoryTest {
+    @Autowired
+    StoreRepository storeRepository;
+
+    Store store;
+
+    StoreSignupRequestDTO dto;
+
+    @BeforeEach
+    void setUp() {
+        dto = StoreSignupRequestDTO.builder()
+                .name("단골손님" + new Random().nextInt())
+                .storePhoneNumber("01012345678")
+                .newAddress("서울특별시 서초구 단골로 130")
+                .sido("서울특별시")
+                .sigungu("서초구")
+                .bname1("단골동")
+                .bname2("")
+                .detailedAddress("")
+                .comments("단골손님 가게로 좋아요.")
+                .officeHours("08:00~10:00")
+                .categoryId(1L)
+                .storeRegisterNumber("1234567890")
+                .storeRegisterName("단골손님")
+                .build();
+
+        store = new Store(dto);
+        storeRepository.save(store);
+    }
+
+    @Test
+    @DisplayName("가게 ID 값을 통해 가게를 조회한다.")
+    void whenFindById_thenReturnStore() {
+        Optional<Store> found = storeRepository.findById(store.getId());
+        assertTrue(found.isPresent());
+        assertEquals(store, found.get());
+    }
+
+    @Test
+    @DisplayName("가게 ID 값을 통해 가게를 수정한다.")
+    void whenFindById_thenUpdateAndCheckStore() {
+        Store updatedStore = null;
+        Optional<Store> found = storeRepository.findById(store.getId());
+
+        if(found.isPresent()) {
+            store.updateName("그냥손님");
+            updatedStore = storeRepository.save(store);
+        }
+
+        assertEquals(updatedStore.getName(), "그냥손님");
+    }
+
+    @Test
+    @DisplayName("가게 ID 값을 통해 가게를 삭제한다.")
+    void whenFindById_thenDeleteStore() {
+        Optional<Store> found = storeRepository.findById(store.getId());
+
+        if(found.isPresent()) {
+            storeRepository.delete(store);
+        }
+
+        assertFalse(storeRepository.findById(store.getId()).isPresent());
+    }
+}

--- a/src/test/java/com/dangol/dangolsonnimbackend/store/repository/dsl/StoreQueryRepositoryTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/store/repository/dsl/StoreQueryRepositoryTest.java
@@ -1,0 +1,61 @@
+package com.dangol.dangolsonnimbackend.store.repository.dsl;
+
+import com.dangol.dangolsonnimbackend.store.domain.Store;
+import com.dangol.dangolsonnimbackend.store.dto.StoreSignupRequestDTO;
+import com.dangol.dangolsonnimbackend.store.repository.StoreRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import javax.transaction.Transactional;
+import java.util.Optional;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class StoreQueryRepositoryTest {
+    @Autowired
+    StoreRepository storeRepository;
+
+    @Autowired
+    StoreQueryRepository storeQueryRepository;
+
+    Store store;
+
+    StoreSignupRequestDTO dto;
+
+    @BeforeEach
+    void setUp() {
+        dto = StoreSignupRequestDTO.builder()
+                .name("단골손님" + new Random().nextInt())
+                .storePhoneNumber("01012345678")
+                .newAddress("서울특별시 서초구 단골로 130")
+                .sido("서울특별시")
+                .sigungu("서초구")
+                .bname1("단골동")
+                .bname2("")
+                .detailedAddress("")
+                .comments("단골손님 가게로 좋아요.")
+                .officeHours("08:00~10:00")
+                .categoryId(1L)
+                .storeRegisterNumber("1234567890")
+                .storeRegisterName("단골손님")
+                .build();
+
+        store = new Store(dto);
+        storeRepository.save(store);
+    }
+
+    @Test
+    @DisplayName("가게 사업자 번호가 중복된 경우를 확인한다.")
+    void givenValidSrn_whenExistsBySrn_thenReturnTrue() {
+        Boolean result = storeQueryRepository.existsBySrn("1234567890");
+
+        assertThat(result).isTrue();
+    }
+}

--- a/src/test/java/com/dangol/dangolsonnimbackend/store/repository/dsl/StoreQueryRepositoryTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/store/repository/dsl/StoreQueryRepositoryTest.java
@@ -20,14 +20,14 @@ import static org.junit.jupiter.api.Assertions.*;
 @Transactional
 class StoreQueryRepositoryTest {
     @Autowired
-    StoreRepository storeRepository;
+    private StoreRepository storeRepository;
 
     @Autowired
-    StoreQueryRepository storeQueryRepository;
+    private StoreQueryRepository storeQueryRepository;
 
-    Store store;
+    private Store store;
 
-    StoreSignupRequestDTO dto;
+    private StoreSignupRequestDTO dto;
 
     @BeforeEach
     void setUp() {

--- a/src/test/java/com/dangol/dangolsonnimbackend/store/repository/dsl/StoreQueryRepositoryTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/store/repository/dsl/StoreQueryRepositoryTest.java
@@ -54,7 +54,7 @@ class StoreQueryRepositoryTest {
     @Test
     @DisplayName("가게 사업자 번호가 중복된 경우를 확인한다.")
     void givenValidSrn_whenExistsBySrn_thenReturnTrue() {
-        Boolean result = storeQueryRepository.existsBySrn("1234567890");
+        Boolean result = storeQueryRepository.existsByRegisterNumber("1234567890");
 
         assertThat(result).isTrue();
     }


### PR DESCRIPTION
## Goals
- 가게의 Repository 클래스 및 테스트를 설계한다.

## Implements
- [x] DS-45에서 정의된 엔티티를 기반으로 한 Repository 클래스 정의
- [x] Repository 클래스 CURD 기능 테스트 추가 

## Related Issue 
- https://dangol-sonnim.atlassian.net/browse/DS-49

## Test
- "가게 ID 값을 통해 가게를 조회한다."
- "가게 ID 값을 통해 가게를 수정한다."
- "가게 ID 값을 통해 가게를 삭제한다."
- "가게 사업자 번호가 중복된 경우를 확인한다."