### PR TITLE
DS-54 [이미지 테이블] Entity & DTO 구현

### DIFF
--- a/src/main/java/com/dangol/dangolsonnimbackend/file/domain/FileAttachment.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/file/domain/FileAttachment.java
@@ -1,0 +1,43 @@
+package com.dangol.dangolsonnimbackend.file.domain;
+
+import com.dangol.dangolsonnimbackend.file.dto.SaveFileDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "tb_file_attachment")
+public class FileAttachment {
+
+    @Id
+    @Column
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long recordId;
+
+    @Column(nullable = false)
+    private String recordType;
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @OneToOne
+    @JoinColumn(name = "blob_id", referencedColumnName = "id")
+    private FileBlob fileBlob;
+
+    public FileAttachment(SaveFileDTO dto) {
+        this.recordId = dto.getRecordId();
+        this.recordType = dto.getRecordType();
+    }
+}

--- a/src/main/java/com/dangol/dangolsonnimbackend/file/domain/FileBlob.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/file/domain/FileBlob.java
@@ -1,0 +1,43 @@
+package com.dangol.dangolsonnimbackend.file.domain;
+
+import com.dangol.dangolsonnimbackend.file.dto.SaveFileDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "tb_file_blob")
+public class FileBlob {
+
+    @Id
+    @Column
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String fileUrl;
+
+    @Column(nullable = false)
+    private String contentType;
+
+    @Column(nullable = false)
+    private Integer byteSize;
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    public FileBlob(SaveFileDTO dto) {
+        this.fileUrl = dto.getFileUrl();
+        this.contentType = dto.getContentType();
+        this.byteSize = dto.getByteSize();
+    }
+}

--- a/src/main/java/com/dangol/dangolsonnimbackend/file/dto/SaveFileDTO.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/file/dto/SaveFileDTO.java
@@ -1,0 +1,26 @@
+package com.dangol.dangolsonnimbackend.file.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+@Setter
+public class SaveFileDTO {
+
+    @NotNull
+    private Long recordId;
+
+    @NotNull
+    private String recordType;
+
+    @NotNull
+    private String fileUrl;
+
+    @NotNull
+    private String contentType;
+
+    @NotNull
+    private Integer byteSize;
+}

--- a/src/test/java/com/dangol/dangolsonnimbackend/file/domain/FileTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/file/domain/FileTest.java
@@ -1,0 +1,25 @@
+package com.dangol.dangolsonnimbackend.file.domain;
+
+import com.dangol.dangolsonnimbackend.file.dto.SaveFileDTO;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class FileTest {
+
+    @Test
+    void testSaveFileDTOToFileAttachmentAndFileBlobConversion() {
+        SaveFileDTO dto = new SaveFileDTO();
+        dto.setRecordId(1L);
+        dto.setRecordType("STORE");
+        dto.setFileUrl("https://test.url");
+        dto.setContentType("image/jpeg");
+        dto.setByteSize(123456);
+
+        FileAttachment fileAttachment = new FileAttachment(dto);
+        FileBlob fileBlob = new FileBlob(dto);
+
+        assertEquals(fileAttachment.getRecordId(), dto.getRecordId());
+        assertEquals(fileBlob.getContentType(), dto.getContentType());
+    }
+}


### PR DESCRIPTION
## Goals
- 파일 연관 관계 & 파일 정보 테이블에 대한 Entity 설계와 DTO을 정의합니다.

## Implements
- [x] FileAttachment Entity
- [x] FileBlob Entity
- [x] SaveFileDTO
- [x] FileTest 

## Related Issue
- https://dangol-sonnim.atlassian.net/jira/software/projects/DS/boards/1?selectedIssue=DS-54

## Test
DTO와 엔티티간의 테스트 진행