### PR TITLE
DS-52 [손님] Repository & Service 구현

### DIFF
--- a/src/main/java/com/dangol/dangolsonnimbackend/customer/domain/CustomerInfo.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/customer/domain/CustomerInfo.java
@@ -42,7 +42,7 @@ public class CustomerInfo {
     private LocalDateTime modifiedAt;
 
     @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    @JoinColumn(name = "customer_id", referencedColumnName = "id")
+    @JoinColumn(name = "customer_id")
     private Customer customer;
 
     public CustomerInfo(CustomerSignupRequestDTO dto) {

--- a/src/main/java/com/dangol/dangolsonnimbackend/customer/domain/CustomerInfo.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/customer/domain/CustomerInfo.java
@@ -41,8 +41,8 @@ public class CustomerInfo {
     @UpdateTimestamp
     private LocalDateTime modifiedAt;
 
-    @OneToOne
-    @JoinColumn(name = "customer_id")
+    @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @JoinColumn(name = "customer_id", referencedColumnName = "id")
     private Customer customer;
 
     public CustomerInfo(CustomerSignupRequestDTO dto) {

--- a/src/main/java/com/dangol/dangolsonnimbackend/customer/repository/CustomerInfoRepository.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/customer/repository/CustomerInfoRepository.java
@@ -1,0 +1,8 @@
+package com.dangol.dangolsonnimbackend.customer.repository;
+
+import com.dangol.dangolsonnimbackend.customer.domain.CustomerInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CustomerInfoRepository extends JpaRepository<CustomerInfo, Long> {
+
+}

--- a/src/main/java/com/dangol/dangolsonnimbackend/customer/repository/CustomerRepository.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/customer/repository/CustomerRepository.java
@@ -1,0 +1,8 @@
+package com.dangol.dangolsonnimbackend.customer.repository;
+
+import com.dangol.dangolsonnimbackend.customer.domain.Customer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CustomerRepository extends JpaRepository<Customer, Long> {
+
+}

--- a/src/main/java/com/dangol/dangolsonnimbackend/customer/repository/dsl/CustomerInfoQueryRepository.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/customer/repository/dsl/CustomerInfoQueryRepository.java
@@ -1,0 +1,31 @@
+package com.dangol.dangolsonnimbackend.customer.repository.dsl;
+
+import com.dangol.dangolsonnimbackend.customer.domain.QCustomerInfo;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomerInfoQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public boolean existsByNickname(String nickname) {
+        Integer fetchOne = queryFactory.selectOne()
+                .from(QCustomerInfo.customerInfo)
+                .where(QCustomerInfo.customerInfo.nickname.eq(nickname))
+                .fetchFirst();
+
+        return fetchOne != null;
+    }
+
+    public boolean existsByPhoneNumber(String phoneNumber) {
+        Integer fetchOne = queryFactory.selectOne()
+                .from(QCustomerInfo.customerInfo)
+                .where(QCustomerInfo.customerInfo.phoneNumber.eq(phoneNumber))
+                .fetchFirst();
+
+        return fetchOne != null;
+    }
+}

--- a/src/main/java/com/dangol/dangolsonnimbackend/customer/repository/dsl/CustomerQueryRepository.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/customer/repository/dsl/CustomerQueryRepository.java
@@ -1,0 +1,13 @@
+package com.dangol.dangolsonnimbackend.customer.repository.dsl;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomerQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+}

--- a/src/main/java/com/dangol/dangolsonnimbackend/customer/service/CustomerService.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/customer/service/CustomerService.java
@@ -1,0 +1,8 @@
+package com.dangol.dangolsonnimbackend.customer.service;
+
+
+import com.dangol.dangolsonnimbackend.customer.dto.CustomerSignupRequestDTO;
+
+public interface CustomerService {
+    void signup(CustomerSignupRequestDTO dto);
+}

--- a/src/main/java/com/dangol/dangolsonnimbackend/customer/service/impl/CustomerServiceImpl.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/customer/service/impl/CustomerServiceImpl.java
@@ -1,0 +1,46 @@
+package com.dangol.dangolsonnimbackend.customer.service.impl;
+
+import com.dangol.dangolsonnimbackend.customer.domain.Customer;
+import com.dangol.dangolsonnimbackend.customer.domain.CustomerInfo;
+import com.dangol.dangolsonnimbackend.customer.dto.CustomerSignupRequestDTO;
+import com.dangol.dangolsonnimbackend.customer.repository.CustomerInfoRepository;
+import com.dangol.dangolsonnimbackend.customer.repository.CustomerRepository;
+import com.dangol.dangolsonnimbackend.customer.repository.dsl.CustomerInfoQueryRepository;
+import com.dangol.dangolsonnimbackend.customer.service.CustomerService;
+import com.dangol.dangolsonnimbackend.errors.BadRequestException;
+import com.dangol.dangolsonnimbackend.errors.enumeration.ErrorCodeMessage;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+
+@Service
+public class CustomerServiceImpl implements CustomerService {
+
+    private final CustomerRepository customerRepository;
+    private final CustomerInfoRepository customerInfoRepository;
+    private final CustomerInfoQueryRepository customerInfoQueryRepository;
+
+    public CustomerServiceImpl(CustomerRepository customerRepository, CustomerInfoRepository customerInfoRepository, CustomerInfoQueryRepository customerInfoQueryRepository) {
+        this.customerRepository = customerRepository;
+        this.customerInfoRepository = customerInfoRepository;
+        this.customerInfoQueryRepository = customerInfoQueryRepository;
+    }
+
+    @Transactional
+    public void signup(CustomerSignupRequestDTO dto) {
+
+        validateDuplicateCustomerInfo(dto);
+
+        customerRepository.save(new Customer(dto));
+        customerInfoRepository.save(new CustomerInfo(dto));
+    }
+
+    private void validateDuplicateCustomerInfo(CustomerSignupRequestDTO dto) {
+        if (customerInfoQueryRepository.existsByNickname(dto.getNickname())) {
+            throw new BadRequestException(ErrorCodeMessage.ALREADY_EXISTS_NICKNAME);
+        }
+        if (customerInfoQueryRepository.existsByPhoneNumber(dto.getPhoneNumber())) {
+            throw new BadRequestException(ErrorCodeMessage.ALREADY_EXISTS_PHONE_NUMBER);
+        }
+    }
+}

--- a/src/main/java/com/dangol/dangolsonnimbackend/errors/enumeration/ErrorCodeMessage.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/errors/enumeration/ErrorCodeMessage.java
@@ -6,7 +6,11 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum ErrorCodeMessage {
-    ;
+    ALREADY_EXISTS_STORE_REGISTER_NUMBER("이미 존재하는 사업자 등록 번호입니다."),
+    ALREADY_EXISTS_EMAIL("이미 존재하는 이메일입니다."),
+    ALREADY_EXISTS_PHONE_NUMBER("이미 존재하는 휴대폰 번호입니다."),
+    ALREADY_EXISTS_NICKNAME("이미 존재하는 닉네임입니다."),
+    BOSS_NOT_FOUND("존재하지 않는 사장님입니다.");
 
     private String message;
 }

--- a/src/test/java/com/dangol/dangolsonnimbackend/customer/repository/CustomerRepositoryTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/customer/repository/CustomerRepositoryTest.java
@@ -1,0 +1,47 @@
+package com.dangol.dangolsonnimbackend.customer.repository;
+
+import com.dangol.dangolsonnimbackend.customer.domain.Customer;
+import com.dangol.dangolsonnimbackend.customer.dto.CustomerSignupRequestDTO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import javax.transaction.Transactional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+@Transactional
+class CustomerRepositoryTest {
+
+    @Autowired
+    private CustomerRepository customerRepository;
+
+    @Autowired
+    private CustomerInfoRepository customerInfoRepository;
+
+    private CustomerSignupRequestDTO dto;
+
+    @BeforeEach
+    public void setup() {
+        dto = new CustomerSignupRequestDTO();
+
+        dto.setName("후추");
+        dto.setEmail("test@kakao.com");
+        dto.setProviderType("KAKAO");
+        dto.setNickname("후추");
+        dto.setProfileImageUrl("https:/test.com");
+        dto.setPhoneNumber("01012345678");
+        dto.setBirth("19900101");
+    }
+
+    @Test
+    void givenSignupDTO_whenSave_thenReturnCustomer() {
+
+        Customer customer = new Customer(dto);
+        Customer savedCustomer = customerRepository.save(customer);
+
+        assertEquals(customer, savedCustomer);
+    }
+}

--- a/src/test/java/com/dangol/dangolsonnimbackend/customer/repository/dsl/CustomerInfoQueryRepositoryTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/customer/repository/dsl/CustomerInfoQueryRepositoryTest.java
@@ -1,0 +1,61 @@
+package com.dangol.dangolsonnimbackend.customer.repository.dsl;
+
+import com.dangol.dangolsonnimbackend.customer.domain.CustomerInfo;
+import com.dangol.dangolsonnimbackend.customer.dto.CustomerSignupRequestDTO;
+import com.dangol.dangolsonnimbackend.customer.repository.CustomerInfoRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import javax.transaction.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Transactional
+@SpringBootTest
+class CustomerInfoQueryRepositoryTest {
+
+    @Autowired
+    private CustomerInfoRepository customerInfoRepository;
+    @Autowired
+    private CustomerInfoQueryRepository customerInfoQueryRepository;
+
+    @BeforeEach
+    public void setUp() {
+
+        CustomerSignupRequestDTO dto = new CustomerSignupRequestDTO();
+
+        dto.setNickname("후추");
+        dto.setProfileImageUrl("https:/test.com");
+        dto.setPhoneNumber("01012345678");
+        dto.setBirth("19900101");
+
+        customerInfoRepository.save(new CustomerInfo(dto));
+    }
+
+    @Test
+    @DisplayName("닉네임 중복 체크")
+    void givenNickname_whenExistsByNickname_thenReturnTrue() {
+        // given
+
+        // when
+        boolean existsByNickname = customerInfoQueryRepository.existsByNickname("후추");
+
+        // then
+        assert existsByNickname;
+    }
+
+    @Test
+    @DisplayName("이메일 중복 체크 - False")
+    void givenPhoneNumber_whenExistsByPhoneNumber_thenReturnFalse() {
+        // given
+
+        // when
+        boolean existsByPhoneNumber = customerInfoQueryRepository.existsByPhoneNumber("01012345679");
+
+        // then
+        assertThat(existsByPhoneNumber).isFalse();
+    }
+}


### PR DESCRIPTION
## Goals
- 손님 가입과 중복 검사를 위한 repository, service 클래스를 생성합니다.

## Implements
- [x] 조회를 위한 querydsl 기반의 queryRepository & 생성, 수정 기능을 위한 JPA 기반의 repository를 생성, 구현합니다.
- [x] service와 serviceImpl 클래스를 구현, 중복 검사를 구현합니다.


## Related Issue
- https://dangol-sonnim.atlassian.net/jira/software/projects/DS/boards/1?selectedIssue=DS-52

## Test
 - 닉네임 중복 체크 확인
 - 이메일 중복 체크 확인
 - create 기능 확인