### PR TITLE
DS-65 [사장님] 사장님 정보 수정 API 추가

### DIFF
--- a/src/main/java/com/dangol/dangolsonnimbackend/boss/controller/BossController.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/boss/controller/BossController.java
@@ -1,5 +1,6 @@
 package com.dangol.dangolsonnimbackend.boss.controller;
 
+import com.dangol.dangolsonnimbackend.boss.dto.BossResponseDTO;
 import com.dangol.dangolsonnimbackend.boss.dto.BossSigninReqeustDTO;
 import com.dangol.dangolsonnimbackend.boss.dto.BossSigninResponseDTO;
 import com.dangol.dangolsonnimbackend.boss.dto.BossSignupRequestDTO;
@@ -21,7 +22,7 @@ public class BossController {
     }
 
     @PostMapping
-    public ResponseEntity<Void> signup(@RequestBody BossSignupRequestDTO dto) {
+    public ResponseEntity<?> signup(@RequestBody BossSignupRequestDTO dto) {
         bossService.signup(dto);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
@@ -33,8 +34,14 @@ public class BossController {
     }
 
     @DeleteMapping
-    public ResponseEntity<Void> withdraw(@AuthenticationPrincipal String email) {
+    public ResponseEntity<?> withdraw(@AuthenticationPrincipal String email) {
         bossService.withdraw(email);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+    @GetMapping
+    public ResponseEntity<?> getBoss(@AuthenticationPrincipal String email) {
+        BossResponseDTO responseDTO = new BossResponseDTO(bossService.findByEmail(email));
+        return ResponseEntity.status(HttpStatus.OK).body(responseDTO);
     }
 }

--- a/src/main/java/com/dangol/dangolsonnimbackend/boss/controller/BossController.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/boss/controller/BossController.java
@@ -1,14 +1,13 @@
 package com.dangol.dangolsonnimbackend.boss.controller;
 
-import com.dangol.dangolsonnimbackend.boss.dto.BossResponseDTO;
-import com.dangol.dangolsonnimbackend.boss.dto.BossSigninReqeustDTO;
-import com.dangol.dangolsonnimbackend.boss.dto.BossSigninResponseDTO;
-import com.dangol.dangolsonnimbackend.boss.dto.BossSignupRequestDTO;
+import com.dangol.dangolsonnimbackend.boss.dto.*;
 import com.dangol.dangolsonnimbackend.boss.service.BossService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
 
 
 @RestController
@@ -22,13 +21,13 @@ public class BossController {
     }
 
     @PostMapping
-    public ResponseEntity<?> signup(@RequestBody BossSignupRequestDTO dto) {
+    public ResponseEntity<?> signup(@Valid @RequestBody BossSignupRequestDTO dto) {
         bossService.signup(dto);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @PostMapping("/signin")
-    public ResponseEntity<?> authenticate(@RequestBody BossSigninReqeustDTO reqeustDTO) {
+    public ResponseEntity<?> authenticate(@Valid @RequestBody BossSigninReqeustDTO reqeustDTO) {
         BossSigninResponseDTO responseDTO = bossService.getByCredentials(reqeustDTO);
         return ResponseEntity.status(HttpStatus.OK).body(responseDTO);
     }
@@ -42,6 +41,12 @@ public class BossController {
     @GetMapping
     public ResponseEntity<?> getBoss(@AuthenticationPrincipal String email) {
         BossResponseDTO responseDTO = new BossResponseDTO(bossService.findByEmail(email));
+        return ResponseEntity.status(HttpStatus.OK).body(responseDTO);
+    }
+
+    @PatchMapping
+    public ResponseEntity<?> update(@AuthenticationPrincipal String email, @Valid @RequestBody BossUpdateRequestDTO reqeustDTO) {
+        BossResponseDTO responseDTO = new BossResponseDTO(bossService.update(email, reqeustDTO));
         return ResponseEntity.status(HttpStatus.OK).body(responseDTO);
     }
 }

--- a/src/main/java/com/dangol/dangolsonnimbackend/boss/domain/Boss.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/boss/domain/Boss.java
@@ -1,6 +1,7 @@
 package com.dangol.dangolsonnimbackend.boss.domain;
 
 import com.dangol.dangolsonnimbackend.boss.dto.BossSignupRequestDTO;
+import com.dangol.dangolsonnimbackend.boss.dto.BossUpdateRequestDTO;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -53,5 +54,10 @@ public class Boss {
         this.phoneNumber = dto.getPhoneNumber();
         this.email = dto.getEmail();
         this.marketingAgreement = dto.getMarketingAgreement();
+    }
+
+    public void updateInfo(BossUpdateRequestDTO dto) {
+        this.phoneNumber = dto.getPhoneNumber() != null ? dto.getPhoneNumber() : this.phoneNumber;
+        this.marketingAgreement = dto.getMarketingAgreement() != null ? dto.getMarketingAgreement() : this.marketingAgreement;
     }
 }

--- a/src/main/java/com/dangol/dangolsonnimbackend/boss/dto/BossResponseDTO.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/boss/dto/BossResponseDTO.java
@@ -16,13 +16,13 @@ public class BossResponseDTO {
     private String phoneNumber;
     private String email;
     private Boolean marketingAgreement;
-    private String createAt;
+    private String createdAt;
 
     public BossResponseDTO(Boss boss){
         this.name = boss.getName();
         this.phoneNumber = boss.getPhoneNumber();
         this.email = boss.getEmail();
         this.marketingAgreement = boss.getMarketingAgreement();
-        this.createAt = String.valueOf(boss.getCreatedAt());
+        this.createdAt = String.valueOf(boss.getCreatedAt());
     }
 }

--- a/src/main/java/com/dangol/dangolsonnimbackend/boss/dto/BossResponseDTO.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/boss/dto/BossResponseDTO.java
@@ -1,0 +1,28 @@
+package com.dangol.dangolsonnimbackend.boss.dto;
+
+import com.dangol.dangolsonnimbackend.boss.domain.Boss;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class BossResponseDTO {
+    private String name;
+    private String phoneNumber;
+    private String email;
+    private Boolean marketingAgreement;
+    private String createAt;
+
+    public BossResponseDTO(Boss boss){
+        this.name = boss.getName();
+        this.phoneNumber = boss.getPhoneNumber();
+        this.email = boss.getEmail();
+        this.marketingAgreement = boss.getMarketingAgreement();
+        this.createAt = String.valueOf(boss.getCreatedAt());
+    }
+}

--- a/src/main/java/com/dangol/dangolsonnimbackend/boss/dto/BossUpdateRequestDTO.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/boss/dto/BossUpdateRequestDTO.java
@@ -1,0 +1,18 @@
+package com.dangol.dangolsonnimbackend.boss.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.Size;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class BossUpdateRequestDTO {
+
+    @Size(min = 11, max = 11, message = "휴대폰 번호는 11자 이여야 합니다.")
+    private String phoneNumber;
+
+    private Boolean marketingAgreement;
+}

--- a/src/main/java/com/dangol/dangolsonnimbackend/boss/service/BossService.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/boss/service/BossService.java
@@ -4,12 +4,13 @@ import com.dangol.dangolsonnimbackend.boss.domain.Boss;
 import com.dangol.dangolsonnimbackend.boss.dto.BossSigninReqeustDTO;
 import com.dangol.dangolsonnimbackend.boss.dto.BossSigninResponseDTO;
 import com.dangol.dangolsonnimbackend.boss.dto.BossSignupRequestDTO;
+import com.dangol.dangolsonnimbackend.boss.dto.BossUpdateRequestDTO;
 
 public interface BossService {
 
     void signup(BossSignupRequestDTO dto);
     void withdraw(String email);
     Boss findByEmail(String email);
-
+    Boss update(String email, BossUpdateRequestDTO dto);
     BossSigninResponseDTO getByCredentials(BossSigninReqeustDTO reqeustDTO);
 }

--- a/src/main/java/com/dangol/dangolsonnimbackend/boss/service/impl/BossServiceImpl.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/boss/service/impl/BossServiceImpl.java
@@ -69,8 +69,9 @@ public class BossServiceImpl implements BossService {
 
     @Transactional
     public Boss update(String email, BossUpdateRequestDTO requestDTO){
-        findByEmail(email).updateInfo(requestDTO);
-        return findByEmail(email);
+        Boss boss = findByEmail(email);
+        boss.updateInfo(requestDTO);
+        return boss;
     }
 
     private void validateSignup(BossSignupRequestDTO dto) {

--- a/src/main/java/com/dangol/dangolsonnimbackend/boss/service/impl/BossServiceImpl.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/boss/service/impl/BossServiceImpl.java
@@ -4,6 +4,7 @@ import com.dangol.dangolsonnimbackend.boss.domain.Boss;
 import com.dangol.dangolsonnimbackend.boss.dto.BossSigninReqeustDTO;
 import com.dangol.dangolsonnimbackend.boss.dto.BossSigninResponseDTO;
 import com.dangol.dangolsonnimbackend.boss.dto.BossSignupRequestDTO;
+import com.dangol.dangolsonnimbackend.boss.dto.BossUpdateRequestDTO;
 import com.dangol.dangolsonnimbackend.boss.repository.BossRepository;
 import com.dangol.dangolsonnimbackend.boss.repository.dsl.BossQueryRepository;
 import com.dangol.dangolsonnimbackend.boss.service.BossService;
@@ -64,6 +65,12 @@ public class BossServiceImpl implements BossService {
 
         final String token = tokenProvider.generateAccessToken(reqeustDTO.getEmail());
         return new BossSigninResponseDTO(token);
+    }
+
+    @Transactional
+    public Boss update(String email, BossUpdateRequestDTO requestDTO){
+        findByEmail(email).updateInfo(requestDTO);
+        return findByEmail(email);
     }
 
     private void validateSignup(BossSignupRequestDTO dto) {

--- a/src/test/java/com/dangol/dangolsonnimbackend/boss/controller/BossControllerTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/boss/controller/BossControllerTest.java
@@ -165,6 +165,6 @@ class BossControllerTest {
         // then
         BossResponseDTO responseDTO = new ObjectMapper().readValue(mvcResult.getResponse().getContentAsString(), BossResponseDTO.class);
         assertEquals(dto.getName(), responseDTO.getName());
-        assertNotNull(responseDTO.getCreateAt());
+        assertNotNull(responseDTO.getCreatedAt());
     }
 }

--- a/src/test/java/com/dangol/dangolsonnimbackend/boss/controller/BossControllerTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/boss/controller/BossControllerTest.java
@@ -1,6 +1,7 @@
 package com.dangol.dangolsonnimbackend.boss.controller;
 
 import com.dangol.dangolsonnimbackend.boss.domain.Boss;
+import com.dangol.dangolsonnimbackend.boss.dto.BossResponseDTO;
 import com.dangol.dangolsonnimbackend.boss.dto.BossSigninReqeustDTO;
 import com.dangol.dangolsonnimbackend.boss.dto.BossSigninResponseDTO;
 import com.dangol.dangolsonnimbackend.boss.dto.BossSignupRequestDTO;
@@ -41,9 +42,6 @@ class BossControllerTest {
     private TokenProvider tokenProvider;
     @Autowired
     private MockMvc mockMvc;
-
-    @Autowired
-    BossRepository bossRepository;
 
     @Test
     void givenSignupDto_whenSignup_thenCreateNewBoss() throws Exception {
@@ -142,5 +140,31 @@ class BossControllerTest {
         // then
         BadRequestException exception = assertThrows(BadRequestException.class, () -> bossService.findByEmail(dto.getEmail()));
         assertEquals(ErrorCodeMessage.BOSS_NOT_FOUND.getMessage(), exception.getMessage());
+    }
+
+    @Test
+    void givenBossEmail_whenGetBoss_thenReturnBoss() throws Exception {
+        // given
+        BossSignupRequestDTO dto = new BossSignupRequestDTO();
+        dto.setName("Test Boss");
+        dto.setEmail("test@example.com");
+        dto.setPassword("password");
+        dto.setPhoneNumber("01012345678");
+        dto.setMarketingAgreement(true);
+        bossService.signup(dto);
+
+        AbstractAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(dto.getEmail(), null, AuthorityUtils.NO_AUTHORITIES);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        // when
+        MvcResult mvcResult = mockMvc.perform(get("/api/v1/boss")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        // then
+        BossResponseDTO responseDTO = new ObjectMapper().readValue(mvcResult.getResponse().getContentAsString(), BossResponseDTO.class);
+        assertEquals(dto.getName(), responseDTO.getName());
+        assertNotNull(responseDTO.getCreateAt());
     }
 }

--- a/src/test/java/com/dangol/dangolsonnimbackend/boss/service/impl/BossServiceImplTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/boss/service/impl/BossServiceImplTest.java
@@ -4,6 +4,7 @@ import com.dangol.dangolsonnimbackend.boss.domain.Boss;
 import com.dangol.dangolsonnimbackend.boss.dto.BossSigninReqeustDTO;
 import com.dangol.dangolsonnimbackend.boss.dto.BossSigninResponseDTO;
 import com.dangol.dangolsonnimbackend.boss.dto.BossSignupRequestDTO;
+import com.dangol.dangolsonnimbackend.boss.dto.BossUpdateRequestDTO;
 import com.dangol.dangolsonnimbackend.boss.repository.BossRepository;
 import com.dangol.dangolsonnimbackend.boss.repository.dsl.BossQueryRepository;
 import com.dangol.dangolsonnimbackend.errors.BadRequestException;
@@ -165,5 +166,21 @@ public class BossServiceImplTest {
 
         // then
         Assertions.assertNull(bossQueryRepository.findByEmail("test@example.com"));
+    }
+
+    @Test
+    void givenUpdateDTO_whenUpdate_thenBossUpdated() {
+
+        // given
+        bossService.signup(validDto);
+        BossUpdateRequestDTO requestDTO = new BossUpdateRequestDTO("01012345678", null);
+
+        // when
+        bossService.update(validDto.getEmail(), requestDTO);
+
+        // then
+        Boss savedBoss = bossQueryRepository.findByEmail("test@test.com");
+        Assertions.assertNotNull(savedBoss.getMarketingAgreement());
+        Assertions.assertEquals(savedBoss.getPhoneNumber(), "01012345678");
     }
 }


### PR DESCRIPTION
## Goals
- 로그인 된(시큐리티 컨텍스트 홀더에 등록) 사장님의 정보를 수정합니다
- 폰번호와 마케팅 수신정보 일부 수정 가능합니다
- PATCH : api/v1/boss

## Implements
- [x] BossController, Service, Entity ...
- [x] BossUpdateRequestDTO
- [x] 각 API 에 @Valid 추가함으로써 DTO 유효성 체크

## Related Issue
https://dangol-sonnim.atlassian.net/browse/DS-65?atlOrigin=eyJpIjoiY2UzZDIwZTUxYjA3NDU0ZTgzOGJjMTFiMWI3ZjBiZDUiLCJwIjoiaiJ9