### PR TITLE
DS-66 [사장님] 사장님 비밀번호 수정 API 추가

### DIFF
--- a/src/main/java/com/dangol/dangolsonnimbackend/boss/controller/BossController.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/boss/controller/BossController.java
@@ -49,4 +49,10 @@ public class BossController {
         BossResponseDTO responseDTO = new BossResponseDTO(bossService.update(email, reqeustDTO));
         return ResponseEntity.status(HttpStatus.OK).body(responseDTO);
     }
+
+    @PutMapping("/password")
+    public ResponseEntity<?> updatePassword(@Valid @RequestBody BossPasswordUpdateReqeuestDTO reqeuestDTO){
+        bossService.updatePassword(reqeuestDTO);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
 }

--- a/src/main/java/com/dangol/dangolsonnimbackend/boss/domain/Boss.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/boss/domain/Boss.java
@@ -60,4 +60,8 @@ public class Boss {
         this.phoneNumber = dto.getPhoneNumber() != null ? dto.getPhoneNumber() : this.phoneNumber;
         this.marketingAgreement = dto.getMarketingAgreement() != null ? dto.getMarketingAgreement() : this.marketingAgreement;
     }
+
+    public void updatePassword(String encodedPassword){
+        this.password = encodedPassword;
+    }
 }

--- a/src/main/java/com/dangol/dangolsonnimbackend/boss/dto/BossPasswordUpdateReqeuestDTO.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/boss/dto/BossPasswordUpdateReqeuestDTO.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 
+import javax.validation.constraints.Email;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
@@ -11,6 +12,11 @@ import javax.validation.constraints.Size;
 @Setter
 @AllArgsConstructor
 public class BossPasswordUpdateReqeuestDTO {
+
+    @NotNull(message = "이메일은 Null 일 수 없습니다.")
+    @Email
+    private String email;
+
     @NotNull
     @Size(min = 8, message = "비밀번호는 8자 이상이여야 합니다.")
     private String password;

--- a/src/main/java/com/dangol/dangolsonnimbackend/boss/dto/BossPasswordUpdateReqeuestDTO.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/boss/dto/BossPasswordUpdateReqeuestDTO.java
@@ -1,0 +1,17 @@
+package com.dangol.dangolsonnimbackend.boss.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class BossPasswordUpdateReqeuestDTO {
+    @NotNull
+    @Size(min = 8, message = "비밀번호는 8자 이상이여야 합니다.")
+    private String password;
+}

--- a/src/main/java/com/dangol/dangolsonnimbackend/boss/service/BossService.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/boss/service/BossService.java
@@ -1,10 +1,7 @@
 package com.dangol.dangolsonnimbackend.boss.service;
 
 import com.dangol.dangolsonnimbackend.boss.domain.Boss;
-import com.dangol.dangolsonnimbackend.boss.dto.BossSigninReqeustDTO;
-import com.dangol.dangolsonnimbackend.boss.dto.BossSigninResponseDTO;
-import com.dangol.dangolsonnimbackend.boss.dto.BossSignupRequestDTO;
-import com.dangol.dangolsonnimbackend.boss.dto.BossUpdateRequestDTO;
+import com.dangol.dangolsonnimbackend.boss.dto.*;
 
 public interface BossService {
 
@@ -12,5 +9,6 @@ public interface BossService {
     void withdraw(String email);
     Boss findByEmail(String email);
     Boss update(String email, BossUpdateRequestDTO dto);
+    void updatePassword(BossPasswordUpdateReqeuestDTO dto);
     BossSigninResponseDTO getByCredentials(BossSigninReqeustDTO reqeustDTO);
 }

--- a/src/main/java/com/dangol/dangolsonnimbackend/boss/service/impl/BossServiceImpl.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/boss/service/impl/BossServiceImpl.java
@@ -1,10 +1,7 @@
 package com.dangol.dangolsonnimbackend.boss.service.impl;
 
 import com.dangol.dangolsonnimbackend.boss.domain.Boss;
-import com.dangol.dangolsonnimbackend.boss.dto.BossSigninReqeustDTO;
-import com.dangol.dangolsonnimbackend.boss.dto.BossSigninResponseDTO;
-import com.dangol.dangolsonnimbackend.boss.dto.BossSignupRequestDTO;
-import com.dangol.dangolsonnimbackend.boss.dto.BossUpdateRequestDTO;
+import com.dangol.dangolsonnimbackend.boss.dto.*;
 import com.dangol.dangolsonnimbackend.boss.repository.BossRepository;
 import com.dangol.dangolsonnimbackend.boss.repository.dsl.BossQueryRepository;
 import com.dangol.dangolsonnimbackend.boss.service.BossService;
@@ -71,6 +68,12 @@ public class BossServiceImpl implements BossService {
     public Boss update(String email, BossUpdateRequestDTO requestDTO){
         findByEmail(email).updateInfo(requestDTO);
         return findByEmail(email);
+    }
+
+    @Transactional
+    public void updatePassword(BossPasswordUpdateReqeuestDTO reqeuestDTO) {
+        Boss boss = findByEmail(reqeuestDTO.getEmail());
+        boss.updatePassword(passwordEncoder.encode(reqeuestDTO.getPassword()));
     }
 
     private void validateSignup(BossSignupRequestDTO dto) {

--- a/src/test/java/com/dangol/dangolsonnimbackend/boss/controller/BossControllerTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/boss/controller/BossControllerTest.java
@@ -45,7 +45,7 @@ class BossControllerTest {
     @Test
     void givenSignupDto_whenSignup_thenCreateNewBoss() throws Exception {
         BossSignupRequestDTO dto = new BossSignupRequestDTO();
-        dto.setName("Test Boss");
+        dto.setName("TestBoss");
         dto.setEmail("test@example.com");
         dto.setPassword("password");
         dto.setPhoneNumber("01012345678");

--- a/src/test/java/com/dangol/dangolsonnimbackend/boss/controller/BossControllerTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/boss/controller/BossControllerTest.java
@@ -8,6 +8,7 @@ import com.dangol.dangolsonnimbackend.boss.repository.BossRepository;
 import com.dangol.dangolsonnimbackend.errors.BadRequestException;
 import com.dangol.dangolsonnimbackend.errors.enumeration.ErrorCodeMessage;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -40,14 +41,22 @@ class BossControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @Test
-    void givenSignupDto_whenSignup_thenCreateNewBoss() throws Exception {
-        BossSignupRequestDTO dto = new BossSignupRequestDTO();
+    private BossSignupRequestDTO dto;
+
+    @BeforeEach
+    void setup(){
+        dto = new BossSignupRequestDTO();
+
         dto.setName("TestBoss");
         dto.setEmail("test@example.com");
         dto.setPassword("password");
         dto.setPhoneNumber("01012345678");
         dto.setMarketingAgreement(true);
+    }
+
+    @Test
+    void givenSignupDto_whenSignup_thenCreateNewBoss() throws Exception {
+
 
         mockMvc.perform(post("/api/v1/boss")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -63,12 +72,6 @@ class BossControllerTest {
     @Test
     void givenValidCredentials_whenAuthenticate_thenSucceed() throws Exception {
         // given
-        BossSignupRequestDTO dto = new BossSignupRequestDTO();
-        dto.setName("Test Boss");
-        dto.setEmail("test@example.com");
-        dto.setPassword("password");
-        dto.setPhoneNumber("01012345678");
-        dto.setMarketingAgreement(true);
         bossService.signup(dto);
 
         BossSigninReqeustDTO requestDTO = new BossSigninReqeustDTO("test@example.com", "password");
@@ -94,12 +97,6 @@ class BossControllerTest {
     @Test
     void givenInvalidCredentials_whenAuthenticate_thenFail() throws Exception {
         // given
-        BossSignupRequestDTO dto = new BossSignupRequestDTO();
-        dto.setName("Test Boss");
-        dto.setEmail("test@example.com");
-        dto.setPassword("password");
-        dto.setPhoneNumber("01012345678");
-        dto.setMarketingAgreement(true);
         bossService.signup(dto);
 
         BossSigninReqeustDTO requestDTO = new BossSigninReqeustDTO("test@example.com", "invalid-password");
@@ -118,12 +115,6 @@ class BossControllerTest {
     @Test
     void givenBossEmail_whenWithdraw_thenDeleteBoss() throws Exception {
         // given
-        BossSignupRequestDTO dto = new BossSignupRequestDTO();
-        dto.setName("Test Boss");
-        dto.setEmail("test@example.com");
-        dto.setPassword("password");
-        dto.setPhoneNumber("01012345678");
-        dto.setMarketingAgreement(true);
         bossService.signup(dto);
 
         AbstractAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(dto.getEmail(), null, AuthorityUtils.NO_AUTHORITIES);
@@ -140,14 +131,8 @@ class BossControllerTest {
     }
 
     @Test
-    void givenBossEmail_whenGetBoss_thenReturnBoss() throws Exception {
+    void givenBossEmail_whenGetBoss_thenReturnBossResponseDTO() throws Exception {
         // given
-        BossSignupRequestDTO dto = new BossSignupRequestDTO();
-        dto.setName("Test Boss");
-        dto.setEmail("test@example.com");
-        dto.setPassword("password");
-        dto.setPhoneNumber("01012345678");
-        dto.setMarketingAgreement(true);
         bossService.signup(dto);
 
         AbstractAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(dto.getEmail(), null, AuthorityUtils.NO_AUTHORITIES);
@@ -166,14 +151,8 @@ class BossControllerTest {
     }
 
     @Test
-    void givenBossEmail_whenUpdate_thenReturnBoss() throws Exception {
+    void givenBossEmail_whenUpdate_thenReturnBossResponseDTO() throws Exception {
         // given
-        BossSignupRequestDTO dto = new BossSignupRequestDTO();
-        dto.setName("Test Boss");
-        dto.setEmail("test@example.com");
-        dto.setPassword("password");
-        dto.setPhoneNumber("01012345678");
-        dto.setMarketingAgreement(true);
         bossService.signup(dto);
 
         BossUpdateRequestDTO requestDTO = new BossUpdateRequestDTO(null, false);
@@ -196,5 +175,22 @@ class BossControllerTest {
         assertEquals(dto.getName(), responseDTO.getName());
         assertEquals(dto.getPhoneNumber(), responseDTO.getPhoneNumber());
         assertEquals(responseDTO.getMarketingAgreement(), false);
+    }
+
+    @Test
+    void givenBossPasswordUpdateReqeuestDTO_whenUpdate_thenReturnBossResponseDTO() throws Exception {
+        // given
+        bossService.signup(dto);
+
+        BossPasswordUpdateReqeuestDTO requestDTO = new BossPasswordUpdateReqeuestDTO("test@example.com", "updatedPassword");
+
+        // when
+        mockMvc.perform(
+                put("/api/v1/boss/password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(requestDTO))
+                        .with(csrf()))
+                // then
+            .andExpect(status().isNoContent());
     }
 }

--- a/src/test/java/com/dangol/dangolsonnimbackend/boss/service/impl/BossServiceImplTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/boss/service/impl/BossServiceImplTest.java
@@ -1,10 +1,7 @@
 package com.dangol.dangolsonnimbackend.boss.service.impl;
 
 import com.dangol.dangolsonnimbackend.boss.domain.Boss;
-import com.dangol.dangolsonnimbackend.boss.dto.BossSigninReqeustDTO;
-import com.dangol.dangolsonnimbackend.boss.dto.BossSigninResponseDTO;
-import com.dangol.dangolsonnimbackend.boss.dto.BossSignupRequestDTO;
-import com.dangol.dangolsonnimbackend.boss.dto.BossUpdateRequestDTO;
+import com.dangol.dangolsonnimbackend.boss.dto.*;
 import com.dangol.dangolsonnimbackend.boss.repository.BossRepository;
 import com.dangol.dangolsonnimbackend.boss.repository.dsl.BossQueryRepository;
 import com.dangol.dangolsonnimbackend.errors.BadRequestException;
@@ -182,5 +179,20 @@ public class BossServiceImplTest {
         Boss savedBoss = bossQueryRepository.findByEmail("test@test.com");
         Assertions.assertNotNull(savedBoss.getMarketingAgreement());
         Assertions.assertEquals(savedBoss.getPhoneNumber(), "01012345678");
+    }
+
+    @Test
+    void givenBossPasswordUpdateReqeuestDTO_whenUpdatePassword_thenSuccess(){
+
+        // given
+        bossService.signup(validDto);
+        BossPasswordUpdateReqeuestDTO requestDTO = new BossPasswordUpdateReqeuestDTO("test@test.com", "updatedPassword");
+
+        // when
+        bossService.updatePassword(requestDTO);
+
+        // then
+        Boss found = bossQueryRepository.findByEmail("test@test.com");
+        Assertions.assertTrue(passwordEncoder.matches("updatedPassword", found.getPassword()));
     }
 }


### PR DESCRIPTION
## Goals
- 사장님의 비밀번호를 수정합니다
- 사장님의 이메일과 변경할 비밀번호를 데이터로 받습니다

## Implements
- [x] BossController, Service, Entity ...
- [x] BossPasswordUpdateRequestDTO
- [x] 비밀번호 변경 테스트 추가

## Related Issue
https://dangol-sonnim.atlassian.net/browse/DS-66?atlOrigin=eyJpIjoiZWJhMGJlY2U0MTA3NGIzZjgxNWUzOWMzMzE1YzA0Y2YiLCJwIjoiaiJ9