### PR TITLE
DS-67 [사장님] 이메일 인증 API 추가

### DIFF
--- a/.github/workflows/develop-ci.yml
+++ b/.github/workflows/develop-ci.yml
@@ -40,7 +40,6 @@ jobs:
 
       - name: STEP2) Make application.yml
         run:
-          mkdir ./src/main/resources |
           touch ./src/main/resources/application.yml
         shell: bash
 

--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,9 @@ dependencies {
 	annotationProcessor("jakarta.annotation:jakarta.annotation-api")
 
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
+
+	implementation group: 'org.springframework.boot', name: 'spring-boot-starter-mail', version: '2.6.3'
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 }
 
 test {

--- a/src/main/java/com/dangol/dangolsonnimbackend/boss/controller/EmailController.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/boss/controller/EmailController.java
@@ -1,0 +1,47 @@
+package com.dangol.dangolsonnimbackend.boss.controller;
+
+import com.dangol.dangolsonnimbackend.boss.dto.AuthCodeRequestDTO;
+import com.dangol.dangolsonnimbackend.boss.dto.AuthCodeResponseDTO;
+import com.dangol.dangolsonnimbackend.boss.service.EmailService;
+import com.dangol.dangolsonnimbackend.errors.BadRequestException;
+import com.dangol.dangolsonnimbackend.errors.enumeration.ErrorCodeMessage;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1/email")
+public class EmailController {
+    private final Map<String, Integer> requestCountMap = new HashMap<>();
+    private static final int MAX_REQUEST_COUNT = 5;
+    private static final int DEFAULT_REQUEST_COUNT = 0;
+    private static final int INCREASE_REQUEST_COUNT = 1;
+    private final EmailService emailService;
+
+    public EmailController(EmailService emailService) {
+        this.emailService = emailService;
+    }
+
+    @PostMapping("/send-auth-code")
+    public ResponseEntity<?> sendAuthCode(@Valid @RequestBody AuthCodeRequestDTO dto) {
+        int requestCount = requestCountMap.getOrDefault(dto.getEmail(), DEFAULT_REQUEST_COUNT);
+
+        if (requestCount >= MAX_REQUEST_COUNT) {
+            throw new BadRequestException(ErrorCodeMessage.DAILY_EMAIL_RESTRICTED);
+        }
+
+        requestCountMap.put(dto.getEmail(), requestCount + INCREASE_REQUEST_COUNT);
+        AuthCodeResponseDTO responseDTO = new AuthCodeResponseDTO(emailService.sendEmail(dto.getEmail()));
+        return ResponseEntity.status(HttpStatus.OK).body(responseDTO);
+    }
+
+    @Scheduled(cron = "0 0 6 * * *")
+    public void resetRequestCount() {
+        requestCountMap.clear();
+    }
+}

--- a/src/main/java/com/dangol/dangolsonnimbackend/boss/dto/AuthCodeRequestDTO.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/boss/dto/AuthCodeRequestDTO.java
@@ -1,0 +1,19 @@
+package com.dangol.dangolsonnimbackend.boss.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotNull;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class AuthCodeRequestDTO {
+    @NotNull(message = "이메일은 Null 일 수 없습니다.")
+    @Email
+    private String email;
+}

--- a/src/main/java/com/dangol/dangolsonnimbackend/boss/dto/AuthCodeResponseDTO.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/boss/dto/AuthCodeResponseDTO.java
@@ -1,0 +1,12 @@
+package com.dangol.dangolsonnimbackend.boss.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class AuthCodeResponseDTO {
+    private String authCode;
+}

--- a/src/main/java/com/dangol/dangolsonnimbackend/boss/service/EmailService.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/boss/service/EmailService.java
@@ -1,0 +1,5 @@
+package com.dangol.dangolsonnimbackend.boss.service;
+
+public interface EmailService {
+    public String sendEmail(String toEmail);
+}

--- a/src/main/java/com/dangol/dangolsonnimbackend/boss/service/impl/EmailServiceImpl.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/boss/service/impl/EmailServiceImpl.java
@@ -58,8 +58,10 @@ public class EmailServiceImpl implements EmailService {
             helper.setText(content, true);
 
             emailSender.send(message);
-        } catch (MessagingException | RuntimeException e) {
+        } catch (MessagingException e) {
             throw new RuntimeException("이메일 전송에 실패하였습니다.", e);
+        } catch (RuntimeException e) {
+            throw new RuntimeException("다른 원인으로 인해 이메일 전송에 실패하였습니다.", e);
         }
     }
 }

--- a/src/main/java/com/dangol/dangolsonnimbackend/boss/service/impl/EmailServiceImpl.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/boss/service/impl/EmailServiceImpl.java
@@ -1,0 +1,65 @@
+package com.dangol.dangolsonnimbackend.boss.service.impl;
+
+import com.dangol.dangolsonnimbackend.boss.service.EmailService;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+import java.util.Random;
+
+@Service
+public class EmailServiceImpl implements EmailService {
+
+    private final JavaMailSender emailSender;
+    private final TemplateEngine templateEngine;
+    private static final String CHAR_POOL = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    private static final int INDEX_ZERO = 0;
+    private static final int INDEX_EIGHT = 8;
+
+    public EmailServiceImpl(JavaMailSender emailSender, TemplateEngine templateEngine) {
+        this.emailSender = emailSender;
+        this.templateEngine = templateEngine;
+    }
+
+    public String sendEmail(String toEmail) {
+        String authCode = generateAuthCode();
+        sendEmailWithTemplate(toEmail, authCode);
+        return authCode;
+    }
+
+    // 랜덤 인증코드 생성
+    private String generateAuthCode() {
+        Random random = new Random();
+        StringBuilder authCode = new StringBuilder();
+        for (int i = INDEX_ZERO; i < INDEX_EIGHT; i++) {
+            int index = random.nextInt(CHAR_POOL.length());
+            authCode.append(CHAR_POOL.charAt(index));
+        }
+        return authCode.toString();
+    }
+
+    private void sendEmailWithTemplate(String toEmail, String authCode) {
+        MimeMessage message = emailSender.createMimeMessage();
+        try {
+            // 템플릿에서 사용될 변수를 저장
+            Context context = new Context();
+            context.setVariable("authCode", authCode);
+            String content = templateEngine.process("mail", context);
+
+            // 이메일 설정
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+            helper.setFrom("jaemisama12@gmail.com");
+            helper.setTo(toEmail);
+            helper.setSubject("단골손님 인증번호");
+            helper.setText(content, true);
+
+            emailSender.send(message);
+        } catch (MessagingException e) {
+            throw new RuntimeException("이메일 전송에 실패하였습니다.", e);
+        }
+    }
+}

--- a/src/main/java/com/dangol/dangolsonnimbackend/boss/service/impl/EmailServiceImpl.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/boss/service/impl/EmailServiceImpl.java
@@ -58,7 +58,7 @@ public class EmailServiceImpl implements EmailService {
             helper.setText(content, true);
 
             emailSender.send(message);
-        } catch (MessagingException e) {
+        } catch (MessagingException | RuntimeException e) {
             throw new RuntimeException("이메일 전송에 실패하였습니다.", e);
         }
     }

--- a/src/main/java/com/dangol/dangolsonnimbackend/errors/enumeration/ErrorCodeMessage.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/errors/enumeration/ErrorCodeMessage.java
@@ -10,7 +10,8 @@ public enum ErrorCodeMessage {
     ALREADY_EXISTS_EMAIL("이미 존재하는 이메일입니다."),
     ALREADY_EXISTS_PHONE_NUMBER("이미 존재하는 휴대폰 번호입니다."),
     PASSWORD_NOT_MATCH("패스워드가 일치하지 않습니다."),
-    BOSS_NOT_FOUND("존재하지 않는 사장님입니다.");
+    BOSS_NOT_FOUND("존재하지 않는 사장님입니다."),
+    DAILY_EMAIL_RESTRICTED("일일 전송 허용 횟수를 초과하였습니다.");
 
     private String message;
 }

--- a/src/main/resources/templates/mail.html
+++ b/src/main/resources/templates/mail.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+
+<body>
+<div style="margin:100px;">
+    <h1> 안녕하세요.</h1>
+    <h1> 구독관리 서비스 "단골손님" 입니다.</h1>
+    <br>
+    <p> 아래 코드를 회원가입 창으로 돌아가 입력해주세요.</p>
+    <br>
+
+    <div align="center" style="border:1px solid black; font-family:verdana;">
+        <h3 style="color:blue"> 회원가입 인증 코드 입니다. </h3>
+        <div style="font-size:130%" th:text="${authCode}"> </div>
+    </div>
+    <br/>
+</div>
+
+
+</body>
+</html>

--- a/src/test/java/com/dangol/dangolsonnimbackend/boss/controller/EmailControllerTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/boss/controller/EmailControllerTest.java
@@ -1,0 +1,63 @@
+//package com.dangol.dangolsonnimbackend.boss.controller;
+//
+//import com.dangol.dangolsonnimbackend.boss.dto.AuthCodeRequestDTO;
+//import com.dangol.dangolsonnimbackend.boss.dto.AuthCodeResponseDTO;
+//import com.fasterxml.jackson.databind.ObjectMapper;
+//import org.junit.jupiter.api.Test;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+//import org.springframework.boot.test.context.SpringBootTest;
+//import org.springframework.http.MediaType;
+//import org.springframework.test.web.servlet.MockMvc;
+//import org.springframework.test.web.servlet.MvcResult;
+//
+//import javax.transaction.Transactional;
+//
+//import static org.junit.jupiter.api.Assertions.*;
+//import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+//import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+//import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+//
+//@SpringBootTest
+//@AutoConfigureMockMvc
+//@Transactional
+//class EmailControllerTest {
+//
+//    @Autowired
+//    private MockMvc mockMvc;
+//
+//    @Test
+//    public void givenEmail_whenSendAuthCode_thenSuccess() throws Exception {
+//        long startTime = System.currentTimeMillis();
+//
+//        // given
+//        String email = "test@example.com";
+//        AuthCodeRequestDTO requestDTO = new AuthCodeRequestDTO();
+//        requestDTO.setEmail(email);
+//
+//        // when 최대 허용 요청 횟수 이내의 요청인 경우
+//        for (int i = 0; i < 5; i++) {
+//            MvcResult result = mockMvc.perform(post("/api/v1/email/send-auth-code")
+//                        .contentType(MediaType.APPLICATION_JSON)
+//                        .content(new ObjectMapper().writeValueAsString(requestDTO))
+//                        .with(csrf())
+//                    )
+//                    .andExpect(status().isOk())
+//                    .andReturn();
+//
+//            // then
+//            String contentAsString = result.getResponse().getContentAsString();
+//            AuthCodeResponseDTO responseDTO = new ObjectMapper().readValue(contentAsString, AuthCodeResponseDTO.class);
+//            assertNotNull(responseDTO.getAuthCode());
+//        }
+//        // when 최대 허용 요청 횟수를 초과한 경우
+//        mockMvc.perform(post("/api/v1/email/send-auth-code")
+//                        .with(csrf())
+//                        .param("email", email))
+//                // then
+//                .andExpect(status().isBadRequest());
+//
+//        long endTime = System.currentTimeMillis();
+//        System.out.println(String.format("코드 실행 시간: %20dms", endTime - startTime));
+//    }
+//}


### PR DESCRIPTION
## Goals
- 이메일을 인증하는 기능입니다.
- 이메일당 하루 인증 횟수는 최대 5회입니다.
- 인증 요청 시 인증 코드를 반환합니다
- 이메일 인증 횟수는 매일 오전 6시에 초기화됩니다.

## Implements
- [x] EmailController, EmailService, EmailServiceImpl
- [x] AuthCodeRequestDTO, AuthCodeResponseDTO
- [x] ~~이메일 인증 테스트 추가~~

## Related Issue
https://dangol-sonnim.atlassian.net/browse/DS-67?atlOrigin=eyJpIjoiYTU2ZmZhMmFmMjJkNDRjMDkyYWZmN2QwNzY0MGI0YWQiLCJwIjoiaiJ9

## Note
이메일 인증 컨트롤러 테스트 진행 했을 때 요청 당 약 10초의 처리 시간이 필요한 것으로 파악되었습니다.
우선 동기식으로 구현하였습니다만, 이후 비동기 전환이 필요해 보입니다.