### PR TITLE
DS-68 [사장님] 사장님 계정찾기 API 추가

### DIFF
--- a/src/main/java/com/dangol/dangolsonnimbackend/boss/controller/BossController.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/boss/controller/BossController.java
@@ -55,4 +55,10 @@ public class BossController {
         bossService.updatePassword(reqeuestDTO);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
+
+    @PostMapping("/find-email")
+    public ResponseEntity<?> findEmail(@Valid @RequestBody BossFindEmailReqeustDTO reqeustDTO){
+        BossFindEmailResponseDTO responseDTO = bossService.findEmailByPhoneNumber(reqeustDTO);
+        return ResponseEntity.status(HttpStatus.OK).body(responseDTO);
+    }
 }

--- a/src/main/java/com/dangol/dangolsonnimbackend/boss/dto/BossFindEmailReqeustDTO.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/boss/dto/BossFindEmailReqeustDTO.java
@@ -1,0 +1,19 @@
+package com.dangol.dangolsonnimbackend.boss.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class BossFindEmailReqeustDTO {
+    @NotNull(message = "휴대폰 번호는 Null 일 수 없습니다.")
+    @Size(min = 11, max = 11, message = "휴대폰 번호는 11자 이여야 합니다.")
+    private String phoneNumber;
+}

--- a/src/main/java/com/dangol/dangolsonnimbackend/boss/dto/BossFindEmailResponseDTO.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/boss/dto/BossFindEmailResponseDTO.java
@@ -1,0 +1,14 @@
+package com.dangol.dangolsonnimbackend.boss.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class BossFindEmailResponseDTO {
+    private String email;
+}

--- a/src/main/java/com/dangol/dangolsonnimbackend/boss/repository/dsl/BossQueryRepository.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/boss/repository/dsl/BossQueryRepository.java
@@ -35,4 +35,10 @@ public class BossQueryRepository {
                 .where(QBoss.boss.email.eq(email))
                 .fetchOne();
     }
+
+    public Boss findByPhoneNumber(String phoneNumber){
+        return queryFactory.selectFrom(QBoss.boss)
+                .where(QBoss.boss.phoneNumber.eq(phoneNumber))
+                .fetchOne();
+    }
 }

--- a/src/main/java/com/dangol/dangolsonnimbackend/boss/service/BossService.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/boss/service/BossService.java
@@ -11,4 +11,5 @@ public interface BossService {
     Boss update(String email, BossUpdateRequestDTO dto);
     void updatePassword(BossPasswordUpdateReqeuestDTO dto);
     BossSigninResponseDTO getByCredentials(BossSigninReqeustDTO reqeustDTO);
+    BossFindEmailResponseDTO findEmailByPhoneNumber(BossFindEmailReqeustDTO reqeustDTO);
 }

--- a/src/main/java/com/dangol/dangolsonnimbackend/boss/service/impl/BossServiceImpl.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/boss/service/impl/BossServiceImpl.java
@@ -78,6 +78,14 @@ public class BossServiceImpl implements BossService {
         boss.updatePassword(passwordEncoder.encode(reqeuestDTO.getPassword()));
     }
 
+    @Transactional(readOnly = true)
+    public BossFindEmailResponseDTO findEmailByPhoneNumber(BossFindEmailReqeustDTO reqeustDTO){
+        Boss boss = Optional.ofNullable(bossQueryRepository.findByPhoneNumber(reqeustDTO.getPhoneNumber())).orElseThrow(
+                () -> new NotFoundException(ErrorCodeMessage.BOSS_NOT_FOUND)
+        );
+        return new BossFindEmailResponseDTO(boss.getEmail());
+    }
+
     private void validateSignup(BossSignupRequestDTO dto) {
         if (bossQueryRepository.existsByEmail(dto.getEmail())) {
             throw new BadRequestException(ErrorCodeMessage.ALREADY_EXISTS_STORE_REGISTER_NUMBER);

--- a/src/test/java/com/dangol/dangolsonnimbackend/boss/controller/BossControllerTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/boss/controller/BossControllerTest.java
@@ -1,6 +1,7 @@
 package com.dangol.dangolsonnimbackend.boss.controller;
 
 import com.dangol.dangolsonnimbackend.boss.domain.Boss;
+import com.dangol.dangolsonnimbackend.boss.dto.BossPasswordUpdateReqeuestDTO;
 import com.dangol.dangolsonnimbackend.boss.dto.BossSigninReqeustDTO;
 import com.dangol.dangolsonnimbackend.boss.dto.BossSigninResponseDTO;
 import com.dangol.dangolsonnimbackend.boss.dto.BossSignupRequestDTO;
@@ -139,5 +140,28 @@ class BossControllerTest {
         // then
         NotFoundException exception = assertThrows(NotFoundException.class, () -> bossService.findByEmail(dto.getEmail()));
         assertEquals(ErrorCodeMessage.BOSS_NOT_FOUND.getMessage(), exception.getMessage());
+    }
+
+    @Test
+    void givenBossPasswordUpdateReqeuestDTO_whenUpdate_thenReturnBossResponseDTO() throws Exception {
+        // given
+        BossSignupRequestDTO dto = new BossSignupRequestDTO();
+        dto.setName("TestBoss");
+        dto.setEmail("test@example.com");
+        dto.setPassword("password");
+        dto.setPhoneNumber("01012345678");
+        dto.setMarketingAgreement(true);
+        bossService.signup(dto);
+
+        BossPasswordUpdateReqeuestDTO requestDTO = new BossPasswordUpdateReqeuestDTO("test@example.com", "updatedPassword");
+
+        // when
+        mockMvc.perform(
+                        put("/api/v1/boss/password")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(new ObjectMapper().writeValueAsString(requestDTO))
+                                .with(csrf()))
+                // then
+                .andExpect(status().isNoContent());
     }
 }

--- a/src/test/java/com/dangol/dangolsonnimbackend/boss/controller/BossControllerTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/boss/controller/BossControllerTest.java
@@ -197,4 +197,33 @@ class BossControllerTest {
         assertEquals(dto.getPhoneNumber(), responseDTO.getPhoneNumber());
         assertEquals(responseDTO.getMarketingAgreement(), false);
     }
+
+    @Test
+    void givenBossPhoneNumber_whenFindByEmail_thenReturnBoss() throws Exception {
+        // given
+        BossSignupRequestDTO dto = new BossSignupRequestDTO();
+        dto.setName("Test Boss");
+        dto.setEmail("test@example.com");
+        dto.setPassword("password");
+        dto.setPhoneNumber("01012345678");
+        dto.setMarketingAgreement(true);
+        bossService.signup(dto);
+
+        BossFindEmailReqeustDTO requestDTO = new BossFindEmailReqeustDTO();
+        requestDTO.setPhoneNumber(dto.getPhoneNumber());
+
+        // when
+        MvcResult mvcResult = mockMvc.perform(
+                        post("/api/v1/boss/find-email")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(new ObjectMapper().writeValueAsString(requestDTO))
+                                .with(csrf())
+                )
+                // then
+                .andExpect(status().isOk())
+                .andReturn();
+
+        BossFindEmailResponseDTO responseDTO = new ObjectMapper().readValue(mvcResult.getResponse().getContentAsString(), BossFindEmailResponseDTO.class);
+        assertEquals(dto.getEmail(), responseDTO.getEmail());
+    }
 }

--- a/src/test/java/com/dangol/dangolsonnimbackend/boss/repository/dsl/BossQueryRepositoryTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/boss/repository/dsl/BossQueryRepositoryTest.java
@@ -89,4 +89,15 @@ class BossQueryRepositoryTest {
         // then
         assertNotNull(boss);
     }
+
+    @Test
+    void givenSignupDto_whenFindByPhoneNumber_thenReturnBoss() {
+        // given
+
+        // when
+        Boss boss = bossQueryRepository.findByEmail("test@test.com");
+
+        // then
+        assertNotNull(boss);
+    }
 }

--- a/src/test/java/com/dangol/dangolsonnimbackend/boss/service/impl/BossServiceImplTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/boss/service/impl/BossServiceImplTest.java
@@ -196,4 +196,18 @@ public class BossServiceImplTest {
         Boss found = bossQueryRepository.findByEmail("test@test.com");
         Assertions.assertTrue(passwordEncoder.matches("updatedPassword", found.getPassword()));
     }
+
+    @Test
+    void givenValidPhoneNumber_whenFindEmail_thenReturnTrue() {
+
+        // given
+        bossService.signup(validDto);
+        BossFindEmailReqeustDTO reqeustDTO = new BossFindEmailReqeustDTO(validDto.getPhoneNumber());
+
+        // when
+        BossFindEmailResponseDTO responseDTO = bossService.findEmailByPhoneNumber(reqeustDTO);
+
+        // then
+        Assertions.assertEquals(responseDTO.getEmail(), validDto.getEmail());
+    }
 }


### PR DESCRIPTION
## Goals
- 사장님 핸드폰 번호 데이터를 가지고 사장님 계정(이메일)을 찾습니다.
- 사장님 계정 찾기 API → POST Mapping : api/v1/boss/find-email 을 구현

## Implements
- [x] BossFindEmailReqeustDTO, BossFindEmailResponseDTO

## Related Issue
https://dangol-sonnim.atlassian.net/browse/DS-68?atlOrigin=eyJpIjoiNzQ4MTY0MjdkZjE3NGRlOWE1ZTg1NWRmZGYyNmZhMzgiLCJwIjoiaiJ9
