### PR TITLE
DS-70 [사장님] 이메일 인증 비동기 적용

### DIFF
--- a/.github/workflows/master-cicd.yml
+++ b/.github/workflows/master-cicd.yml
@@ -47,7 +47,6 @@ jobs:
 
       - name: STEP2) Make application.yml
         run: |
-          mkdir ./src/main/resources
           touch ./src/main/resources/application.yml
           touch ./src/main/resources/application-dev.yml
         shell: bash

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
-
+	implementation 'org.apache.commons:commons-lang3:3.12.0'
 	/**
 	 * Query Dsl 관련 dependency 추가
 	 **/
@@ -52,6 +52,8 @@ dependencies {
 	annotationProcessor("jakarta.annotation:jakarta.annotation-api")
 
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
+	implementation group: 'org.springframework.boot', name: 'spring-boot-starter-mail', version: '2.6.3'
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.apache.commons:commons-lang3:3.12.0'
 
 	/**
 	 * Query Dsl 관련 dependency 추가

--- a/src/main/java/com/dangol/dangolsonnimbackend/boss/service/EmailService.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/boss/service/EmailService.java
@@ -1,5 +1,8 @@
 package com.dangol.dangolsonnimbackend.boss.service;
 
+import java.util.concurrent.CompletableFuture;
+
 public interface EmailService {
-    public String sendEmail(String toEmail);
+    void sendEmail(String toEmail, String AuthCode);
+    String generateAuthCode();
 }

--- a/src/main/java/com/dangol/dangolsonnimbackend/boss/service/impl/EmailServiceImpl.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/boss/service/impl/EmailServiceImpl.java
@@ -1,8 +1,10 @@
 package com.dangol.dangolsonnimbackend.boss.service.impl;
 
 import com.dangol.dangolsonnimbackend.boss.service.EmailService;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
@@ -17,7 +19,6 @@ public class EmailServiceImpl implements EmailService {
     private final JavaMailSender emailSender;
     private final TemplateEngine templateEngine;
     private static final String CHAR_POOL = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-    private static final int INDEX_ZERO = 0;
     private static final int INDEX_EIGHT = 8;
 
     public EmailServiceImpl(JavaMailSender emailSender, TemplateEngine templateEngine) {
@@ -25,21 +26,14 @@ public class EmailServiceImpl implements EmailService {
         this.templateEngine = templateEngine;
     }
 
-    public String sendEmail(String toEmail) {
-        String authCode = generateAuthCode();
+    @Async
+    public void sendEmail(String toEmail, String authCode) {
         sendEmailWithTemplate(toEmail, authCode);
-        return authCode;
     }
 
     // 랜덤 인증코드 생성
-    private String generateAuthCode() {
-        Random random = new Random();
-        StringBuilder authCode = new StringBuilder();
-        for (int i = INDEX_ZERO; i < INDEX_EIGHT; i++) {
-            int index = random.nextInt(CHAR_POOL.length());
-            authCode.append(CHAR_POOL.charAt(index));
-        }
-        return authCode.toString();
+    public String generateAuthCode() {
+        return RandomStringUtils.random(INDEX_EIGHT, CHAR_POOL);
     }
 
     private void sendEmailWithTemplate(String toEmail, String authCode) {

--- a/src/test/java/com/dangol/dangolsonnimbackend/boss/controller/EmailControllerTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/boss/controller/EmailControllerTest.java
@@ -1,63 +1,63 @@
-//package com.dangol.dangolsonnimbackend.boss.controller;
-//
-//import com.dangol.dangolsonnimbackend.boss.dto.AuthCodeRequestDTO;
-//import com.dangol.dangolsonnimbackend.boss.dto.AuthCodeResponseDTO;
-//import com.fasterxml.jackson.databind.ObjectMapper;
-//import org.junit.jupiter.api.Test;
-//import org.springframework.beans.factory.annotation.Autowired;
-//import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-//import org.springframework.boot.test.context.SpringBootTest;
-//import org.springframework.http.MediaType;
-//import org.springframework.test.web.servlet.MockMvc;
-//import org.springframework.test.web.servlet.MvcResult;
-//
-//import javax.transaction.Transactional;
-//
-//import static org.junit.jupiter.api.Assertions.*;
-//import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-//import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-//import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-//
-//@SpringBootTest
-//@AutoConfigureMockMvc
-//@Transactional
-//class EmailControllerTest {
-//
-//    @Autowired
-//    private MockMvc mockMvc;
-//
-//    @Test
-//    public void givenEmail_whenSendAuthCode_thenSuccess() throws Exception {
-//        long startTime = System.currentTimeMillis();
-//
-//        // given
-//        String email = "test@example.com";
-//        AuthCodeRequestDTO requestDTO = new AuthCodeRequestDTO();
-//        requestDTO.setEmail(email);
-//
-//        // when 최대 허용 요청 횟수 이내의 요청인 경우
-//        for (int i = 0; i < 5; i++) {
-//            MvcResult result = mockMvc.perform(post("/api/v1/email/send-auth-code")
-//                        .contentType(MediaType.APPLICATION_JSON)
-//                        .content(new ObjectMapper().writeValueAsString(requestDTO))
-//                        .with(csrf())
-//                    )
-//                    .andExpect(status().isOk())
-//                    .andReturn();
-//
-//            // then
-//            String contentAsString = result.getResponse().getContentAsString();
-//            AuthCodeResponseDTO responseDTO = new ObjectMapper().readValue(contentAsString, AuthCodeResponseDTO.class);
-//            assertNotNull(responseDTO.getAuthCode());
-//        }
-//        // when 최대 허용 요청 횟수를 초과한 경우
-//        mockMvc.perform(post("/api/v1/email/send-auth-code")
-//                        .with(csrf())
-//                        .param("email", email))
-//                // then
-//                .andExpect(status().isBadRequest());
-//
-//        long endTime = System.currentTimeMillis();
-//        System.out.println(String.format("코드 실행 시간: %20dms", endTime - startTime));
-//    }
-//}
+package com.dangol.dangolsonnimbackend.boss.controller;
+
+import com.dangol.dangolsonnimbackend.boss.dto.AuthCodeRequestDTO;
+import com.dangol.dangolsonnimbackend.boss.dto.AuthCodeResponseDTO;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import javax.transaction.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class EmailControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    public void givenEmail_whenSendAuthCode_thenSuccess() throws Exception {
+        long startTime = System.currentTimeMillis();
+
+        // given
+        String email = "test@example.com";
+        AuthCodeRequestDTO requestDTO = new AuthCodeRequestDTO();
+        requestDTO.setEmail(email);
+
+        // when 최대 허용 요청 횟수 이내의 요청인 경우
+        for (int i = 0; i < 5; i++) {
+            MvcResult result = mockMvc.perform(post("/api/v1/email/send-auth-code")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(requestDTO))
+                        .with(csrf())
+                    )
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            // then
+            String contentAsString = result.getResponse().getContentAsString();
+            AuthCodeResponseDTO responseDTO = new ObjectMapper().readValue(contentAsString, AuthCodeResponseDTO.class);
+            assertNotNull(responseDTO.getAuthCode());
+        }
+        // when 최대 허용 요청 횟수를 초과한 경우
+        mockMvc.perform(post("/api/v1/email/send-auth-code")
+                        .with(csrf())
+                        .param("email", email))
+                // then
+                .andExpect(status().isBadRequest());
+
+        long endTime = System.currentTimeMillis();
+        System.out.println(String.format("코드 실행 시간: %20dms", endTime - startTime));
+    }
+}

--- a/src/test/java/com/dangol/dangolsonnimbackend/boss/controller/EmailControllerTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/boss/controller/EmailControllerTest.java
@@ -28,7 +28,6 @@ class EmailControllerTest {
 
     @Test
     public void givenEmail_whenSendAuthCode_thenSuccess() throws Exception {
-        long startTime = System.currentTimeMillis();
 
         // given
         String email = "test@example.com";
@@ -58,6 +57,5 @@ class EmailControllerTest {
                 .andExpect(status().isBadRequest());
 
         long endTime = System.currentTimeMillis();
-        System.out.println(String.format("코드 실행 시간: %20dms", endTime - startTime));
     }
 }

--- a/src/test/java/com/dangol/dangolsonnimbackend/boss/service/impl/EmailServiceImplTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/boss/service/impl/EmailServiceImplTest.java
@@ -1,0 +1,22 @@
+package com.dangol.dangolsonnimbackend.boss.service.impl;
+
+import com.dangol.dangolsonnimbackend.boss.service.EmailService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@SpringBootTest
+class EmailServiceImplTest {
+
+    @Autowired
+    private EmailService emailService;
+
+    @Test
+    void testGenerateAuthCode() {
+        String authCode = emailService.generateAuthCode();
+        assertThat(authCode).hasSize(8);
+    }
+
+}


### PR DESCRIPTION
## Goals
- 이메일 인증에 비동기를 적용하여 다른 요청에 차질이 없도록 개선합니다.

## Implements
- [x] 서비스에 @Async 적용

## Related Issue 
- https://dangol-sonnim.atlassian.net/browse/DS-70?atlOrigin=eyJpIjoiNDFhMjIwM2I3OWQ3NGMwNDg5ZTlkMGE1MTBlZWJkMzgiLCJwIjoiaiJ9

## Test
- 랜덤 인증코드 반환되는 지 확인
- 이메일 인증 6회 요청 시 60000ms -> 471ms 로 시간복잡도 개선

![image](https://user-images.githubusercontent.com/59470153/221368445-7ad76f7a-a1c6-4b0d-bf28-ee1d951e8c57.png)
