### PR TITLE
DS-77 [기능구현] 어플리케이션 헬스 체크 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
 	/**
 	 * Query Dsl 관련 dependency 추가


### PR DESCRIPTION
## Goals
- 어플리케이션 헬스 체크 추가
- GET 매핑으로 /actuator/health url 요청 시 서버의 상태를 응답합니다.

## Implements
- build.gradle 에 implementation 'org.springframework.boot:spring-boot-starter-actuator' 추가

## Related Issue 
- https://dangol-sonnim.atlassian.net/browse/DS-77?atlOrigin=eyJpIjoiY2EyYWU1MGIxOGQzNDEyNzkwZTA5MmFhMzkwODJkZTYiLCJwIjoiaiJ9

## Test
- 인증된 프레임워크이기에 따로 테스트는 진행하지 않습니다