### PR TITLE
DS-56 [가게] Controller 클래스 설계 및 정의

### DIFF
--- a/src/main/java/com/dangol/dangolsonnimbackend/boss/dto/BossSigninReqeustDTO.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/boss/dto/BossSigninReqeustDTO.java
@@ -2,6 +2,7 @@ package com.dangol.dangolsonnimbackend.boss.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import javax.validation.constraints.Email;
@@ -10,6 +11,7 @@ import javax.validation.constraints.Size;
 
 @Getter
 @Setter
+@NoArgsConstructor
 @AllArgsConstructor
 public class BossSigninReqeustDTO {
 

--- a/src/main/java/com/dangol/dangolsonnimbackend/boss/dto/BossSignupRequestDTO.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/boss/dto/BossSignupRequestDTO.java
@@ -1,6 +1,7 @@
 package com.dangol.dangolsonnimbackend.boss.dto;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import javax.validation.constraints.Email;
@@ -9,6 +10,7 @@ import javax.validation.constraints.Size;
 
 @Getter
 @Setter
+@NoArgsConstructor
 public class BossSignupRequestDTO {
 
     @NotNull(message = "이름은 Null 일 수 없습니다.")

--- a/src/main/java/com/dangol/dangolsonnimbackend/boss/dto/BossUpdateRequestDTO.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/boss/dto/BossUpdateRequestDTO.java
@@ -2,12 +2,14 @@ package com.dangol.dangolsonnimbackend.boss.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import javax.validation.constraints.Size;
 
 @Getter
 @Setter
+@NoArgsConstructor
 @AllArgsConstructor
 public class BossUpdateRequestDTO {
 

--- a/src/main/java/com/dangol/dangolsonnimbackend/config/JsonMapperConfig.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/config/JsonMapperConfig.java
@@ -1,0 +1,15 @@
+package com.dangol.dangolsonnimbackend.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JsonMapperConfig {
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper()
+                .registerModule(new Jdk8Module());
+    }
+}

--- a/src/main/java/com/dangol/dangolsonnimbackend/errors/RestApiExceptionHandler.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/errors/RestApiExceptionHandler.java
@@ -24,7 +24,7 @@ public class RestApiExceptionHandler {
         return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
     }
 
-    @ExceptionHandler(value = {InternalServerException.class})
+    @ExceptionHandler(value = {InternalServerException.class, RuntimeException.class})
     public ResponseEntity<ErrorResponse> handleInternalServerException(InternalServerException ex) {
         // MDC 는 에러 로그를 식별하기 위해 사용됩니다.
         String requestId = UUID.randomUUID().toString();

--- a/src/main/java/com/dangol/dangolsonnimbackend/errors/enumeration/ErrorCodeMessage.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/errors/enumeration/ErrorCodeMessage.java
@@ -14,6 +14,7 @@ public enum ErrorCodeMessage {
     PASSWORD_NOT_MATCH("패스워드가 일치하지 않습니다."),
     BOSS_NOT_FOUND("존재하지 않는 사장님입니다."),
     STORE_NOT_FOUND("존재하지 않는 가게입니다."),
+    REQUEST_NOT_INVALID("요청 데이터의 JSON 형식이 적절하지 않습니다."),
 
     // 500
     RESPONSE_CREATE_ERROR("응답 데이터를 생성하던 도중 에러가 발생하였습니다.");

--- a/src/main/java/com/dangol/dangolsonnimbackend/store/controller/StoreController.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/store/controller/StoreController.java
@@ -28,7 +28,7 @@ public class StoreController {
         this.objectMapper = objectMapper;
     }
 
-    @PostMapping("/signup")
+    @PostMapping("/create")
     public ResponseEntity<StoreResponseDTO> signup(@RequestBody StoreSignupRequestDTO dto) {
         StoreResponseDTO res = storeService.signup(dto);
 

--- a/src/main/java/com/dangol/dangolsonnimbackend/store/controller/StoreController.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/store/controller/StoreController.java
@@ -1,0 +1,65 @@
+package com.dangol.dangolsonnimbackend.store.controller;
+
+import com.dangol.dangolsonnimbackend.errors.InternalServerException;
+import com.dangol.dangolsonnimbackend.errors.enumeration.ErrorCodeMessage;
+import com.dangol.dangolsonnimbackend.store.dto.StoreResponseDTO;
+import com.dangol.dangolsonnimbackend.store.dto.StoreSignupRequestDTO;
+import com.dangol.dangolsonnimbackend.store.dto.StoreUpdateDTO;
+import com.dangol.dangolsonnimbackend.store.service.StoreService;
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1/store")
+public class StoreController {
+
+    private final StoreService storeService;
+    private final ObjectMapper objectMapper;
+
+    @Autowired
+    public StoreController(StoreService storeService, ObjectMapper objectMapper) {
+        this.storeService = storeService;
+        this.objectMapper = objectMapper;
+    }
+
+    @PostMapping("/signup")
+    public ResponseEntity<StoreResponseDTO> signup(@RequestBody StoreSignupRequestDTO dto) {
+        StoreResponseDTO res = storeService.signup(dto);
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(res);
+    }
+
+    @GetMapping("/find")
+    public ResponseEntity<StoreResponseDTO> findById(@RequestParam Map<String, String> params) {
+        StoreResponseDTO res = storeService.findById(Long.valueOf(params.get("id")));
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(res);
+    }
+
+    @PutMapping("/update")
+    public ResponseEntity<StoreResponseDTO> update(@RequestBody String jsonString) {
+        try {
+            StoreUpdateDTO dto = objectMapper.readValue(jsonString, StoreUpdateDTO.class);
+            StoreResponseDTO res = storeService.updateStoreByDto(dto);
+
+            return ResponseEntity
+                    .status(HttpStatus.OK)
+                    .body(res);
+
+        } catch (JacksonException e) {
+            throw new InternalServerException(ErrorCodeMessage.REQUEST_NOT_INVALID);
+        } catch (RuntimeException e) {
+            throw new InternalServerException(ErrorCodeMessage.RESPONSE_CREATE_ERROR);
+        }
+     }
+}

--- a/src/main/java/com/dangol/dangolsonnimbackend/store/controller/StoreController.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/store/controller/StoreController.java
@@ -13,6 +13,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
 import java.util.Map;
 
 @RestController
@@ -29,7 +30,7 @@ public class StoreController {
     }
 
     @PostMapping("/create")
-    public ResponseEntity<StoreResponseDTO> signup(@RequestBody StoreSignupRequestDTO dto) {
+    public ResponseEntity<StoreResponseDTO> signup(@Valid @RequestBody StoreSignupRequestDTO dto) {
         StoreResponseDTO res = storeService.signup(dto);
 
         return ResponseEntity

--- a/src/main/java/com/dangol/dangolsonnimbackend/store/controller/StoreController.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/store/controller/StoreController.java
@@ -1,6 +1,6 @@
 package com.dangol.dangolsonnimbackend.store.controller;
 
-import com.dangol.dangolsonnimbackend.errors.InternalServerException;
+import com.dangol.dangolsonnimbackend.errors.BadRequestException;
 import com.dangol.dangolsonnimbackend.errors.enumeration.ErrorCodeMessage;
 import com.dangol.dangolsonnimbackend.store.dto.StoreResponseDTO;
 import com.dangol.dangolsonnimbackend.store.dto.StoreSignupRequestDTO;
@@ -47,7 +47,7 @@ public class StoreController {
     }
 
     @PutMapping("/update")
-    public ResponseEntity<StoreResponseDTO> update(@RequestBody String jsonString) {
+    public ResponseEntity<StoreResponseDTO> update(@RequestBody String jsonString) throws BadRequestException {
         try {
             StoreUpdateDTO dto = objectMapper.readValue(jsonString, StoreUpdateDTO.class);
             StoreResponseDTO res = storeService.updateStoreByDto(dto);
@@ -57,9 +57,7 @@ public class StoreController {
                     .body(res);
 
         } catch (JacksonException e) {
-            throw new InternalServerException(ErrorCodeMessage.REQUEST_NOT_INVALID);
-        } catch (RuntimeException e) {
-            throw new InternalServerException(ErrorCodeMessage.RESPONSE_CREATE_ERROR);
+            throw new BadRequestException(ErrorCodeMessage.REQUEST_NOT_INVALID);
         }
-     }
+    }
 }

--- a/src/main/java/com/dangol/dangolsonnimbackend/store/controller/StoreController.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/store/controller/StoreController.java
@@ -47,7 +47,7 @@ public class StoreController {
                 .body(res);
     }
 
-    @PutMapping("/update")
+    @PatchMapping("/update")
     public ResponseEntity<StoreResponseDTO> update(@RequestBody String jsonString) throws BadRequestException {
         try {
             StoreUpdateDTO dto = objectMapper.readValue(jsonString, StoreUpdateDTO.class);

--- a/src/main/java/com/dangol/dangolsonnimbackend/store/dto/StoreResponseDTO.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/store/dto/StoreResponseDTO.java
@@ -21,6 +21,8 @@ public class StoreResponseDTO {
 
     private String comments;
 
+    private String sido;
+
     private String sigungu;
 
     private String bname1;
@@ -28,6 +30,10 @@ public class StoreResponseDTO {
     private String bname2;
 
     private String detailedAddress;
+
+    private String registerNumber;
+
+    private String registerName;
 
     // TODO. 태그 및 이미지 필드 추가
 
@@ -37,9 +43,12 @@ public class StoreResponseDTO {
         this.newAddress = store.getNewAddress();
         this.categoryId = store.getCategoryId();
         this.comments = store.getComments();
+        this.sido = store.getSido();
         this.sigungu = store.getSigungu();
         this.bname1 = store.getBname1();
         this.bname2 = store.getBname2();
         this.detailedAddress = store.getDetailedAddress();
+        this.registerNumber = store.getRegisterNumber();
+        this.registerName = store.getRegisterName();
     }
 }

--- a/src/test/java/com/dangol/dangolsonnimbackend/store/controller/StoreControllerTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/store/controller/StoreControllerTest.java
@@ -64,7 +64,7 @@ public class StoreControllerTest {
     @Transactional
     @DisplayName("새로운 가게 정보 생성을 요청하면 정상적으로 생성이 된다.")
     void givenSignupDto_whenSignup_thenCreateNewStore() throws Exception {
-        mockMvc.perform(post("/api/v1/store/signup")
+        mockMvc.perform(post("/api/v1/store/create")
                         .contentType(MediaType.APPLICATION_JSON)
                         .with(SecurityMockMvcRequestPostProcessors.csrf())
                         .content(objectMapper.writeValueAsString(dto)))

--- a/src/test/java/com/dangol/dangolsonnimbackend/store/controller/StoreControllerTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/store/controller/StoreControllerTest.java
@@ -1,0 +1,124 @@
+package com.dangol.dangolsonnimbackend.store.controller;
+
+import com.dangol.dangolsonnimbackend.errors.BadRequestException;
+import com.dangol.dangolsonnimbackend.store.dto.StoreSignupRequestDTO;
+import com.dangol.dangolsonnimbackend.store.dto.StoreUpdateDTO;
+import com.dangol.dangolsonnimbackend.store.service.StoreService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.MockMvc;
+
+import javax.transaction.Transactional;
+import java.util.Optional;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class StoreControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private StoreService storeService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private StoreSignupRequestDTO dto;
+
+    @BeforeEach
+    void setup() {
+        dto = StoreSignupRequestDTO.builder()
+                .name("단골손님" + new Random().nextInt())
+                .phoneNumber("01012345678")
+                .newAddress("서울특별시 서초구 단골로 130")
+                .sido("서울특별시")
+                .sigungu("서초구")
+                .bname1("단골동")
+                .bname2("")
+                .detailedAddress("")
+                .comments("단골손님 가게로 좋아요.")
+                .officeHours("08:00~10:00")
+                .categoryId(1L)
+                .registerNumber("1234567890")
+                .registerName("단골손님")
+                .build();
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("새로운 가게 정보 생성을 요청하면 정상적으로 생성이 된다.")
+    void givenSignupDto_whenSignup_thenCreateNewStore() throws Exception {
+        mockMvc.perform(post("/api/v1/store/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .with(SecurityMockMvcRequestPostProcessors.csrf())
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").exists())
+                .andExpect(jsonPath("$.name").value(dto.getName()))
+                .andExpect(jsonPath("$.newAddress").value(dto.getNewAddress()))
+                .andExpect(jsonPath("$.categoryId").value(dto.getCategoryId()))
+                .andExpect(jsonPath("$.comments").value(dto.getComments()))
+                .andExpect(jsonPath("$.sigungu").value(dto.getSigungu()))
+                .andExpect(jsonPath("$.bname1").value(dto.getBname1()))
+                .andExpect(jsonPath("$.bname2").value(dto.getBname2()))
+                .andExpect(jsonPath("$.detailedAddress").value(dto.getDetailedAddress()));
+
+        // 재등록 시에 이미 존재하는 사업자 번호로 반환
+        assertThrows(BadRequestException.class, () -> storeService.signup(dto));
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("특정 가게 아이디 값을 통해 가게를 검색할 수 있다.")
+    void givenStoreId_whenFindById_thenReturnStore() throws Exception {
+        Long id = storeService.signup(dto).getId();
+
+        mockMvc.perform(get("/api/v1/store/find?id="+ id)
+                        .with(SecurityMockMvcRequestPostProcessors.csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").exists())
+                .andExpect(jsonPath("$.name").value(dto.getName()))
+                .andExpect(jsonPath("$.newAddress").value(dto.getNewAddress()))
+                .andExpect(jsonPath("$.categoryId").value(dto.getCategoryId()))
+                .andExpect(jsonPath("$.comments").value(dto.getComments()))
+                .andExpect(jsonPath("$.sigungu").value(dto.getSigungu()))
+                .andExpect(jsonPath("$.bname1").value(dto.getBname1()))
+                .andExpect(jsonPath("$.bname2").value(dto.getBname2()))
+                .andExpect(jsonPath("$.detailedAddress").value(dto.getDetailedAddress()));
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("특정 가게 정보를 업데이트하여 정보를 수정할 수 있다.")
+    void givenStore_whenUpdate_thenUpdateStore() throws Exception {
+        String registerNumber = storeService.signup(dto).getRegisterNumber();
+
+        StoreUpdateDTO updateDTO = new StoreUpdateDTO(registerNumber);
+
+        updateDTO.setName(Optional.of("단골손님" + new Random().nextInt()));
+        updateDTO.setSido(Optional.of("경기도"));
+
+        mockMvc.perform(put("/api/v1/store/update")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .with(SecurityMockMvcRequestPostProcessors.csrf())
+                        .content(objectMapper.writeValueAsString(updateDTO)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value(updateDTO.getName().get()))
+                .andExpect(jsonPath("$.sido").value(updateDTO.getSido().get()));
+    }
+}

--- a/src/test/java/com/dangol/dangolsonnimbackend/store/controller/StoreControllerTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/store/controller/StoreControllerTest.java
@@ -114,7 +114,7 @@ public class StoreControllerTest {
         updateDTO.setName(Optional.of("단골손님" + new Random().nextInt()));
         updateDTO.setSido(Optional.of("경기도"));
 
-        mockMvc.perform(put("/api/v1/store/update")
+        mockMvc.perform(patch("/api/v1/store/update")
                         .contentType(MediaType.APPLICATION_JSON)
                         .with(SecurityMockMvcRequestPostProcessors.csrf())
                         .content(objectMapper.writeValueAsString(updateDTO)))
@@ -129,7 +129,7 @@ public class StoreControllerTest {
     void givenNonExistedStore_whenUpdate_thenThrowException() throws Exception {
         StoreUpdateDTO updateDTO = new StoreUpdateDTO("None");
 
-        mockMvc.perform(put("/api/v1/store/update")
+        mockMvc.perform(patch("/api/v1/store/update")
                         .contentType(MediaType.APPLICATION_JSON)
                            .with(SecurityMockMvcRequestPostProcessors.csrf())
                         .content(objectMapper.writeValueAsString(updateDTO)))

--- a/src/test/java/com/dangol/dangolsonnimbackend/store/controller/StoreControllerTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/store/controller/StoreControllerTest.java
@@ -19,6 +19,7 @@ import javax.transaction.Transactional;
 import java.util.Optional;
 import java.util.Random;
 
+import static com.dangol.dangolsonnimbackend.errors.enumeration.ErrorCodeMessage.STORE_NOT_FOUND;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -120,5 +121,19 @@ public class StoreControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.name").value(updateDTO.getName().get()))
                 .andExpect(jsonPath("$.sido").value(updateDTO.getSido().get()));
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("존재하지 않은 가게 정보로 업데이트를 요청하면 Bad Request를 반환받는다.")
+    void givenNonExistedStore_whenUpdate_thenThrowException() throws Exception {
+        StoreUpdateDTO updateDTO = new StoreUpdateDTO("None");
+
+        mockMvc.perform(put("/api/v1/store/update")
+                        .contentType(MediaType.APPLICATION_JSON)
+                           .with(SecurityMockMvcRequestPostProcessors.csrf())
+                        .content(objectMapper.writeValueAsString(updateDTO)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value(STORE_NOT_FOUND.getMessage()));
     }
 }


### PR DESCRIPTION
## Goals
- 가게 컨트롤러 클래스를 설계 및 정의한다.

## Implements
- [x] 응답 데이터로 활용되는 DTO 구조체에 누락된 필드 추가
- [x] 가게 컨트롤러 클래스 정의 및 구현
- [x] 예외 메세지 및 핸들러 스펙 추가
- [x] Json 직렬화/역직렬화용 Bean 추가
- [x] 가게 컨트롤러 클래스 테스트 추가   

## Related Issue 
- https://dangol-sonnim.atlassian.net/browse/DS-56

## Test
- "새로운 가게 정보 생성을 요청하면 정상적으로 생성이 된다."
- "특정 가게 아이디 값을 통해 가게를 검색할 수 있다."
- "특정 가게 정보를 업데이트하여 정보를 수정할 수 있다."
- "존재하지 않은 가게 정보로 업데이트를 요청하면 Bad Request를 반환받는다."