### PR TITLE
DS-83 [가게] REST Docs를 적용하여 명세서 작성

### DIFF
--- a/src/docs/asciidoc/dangol-backend-api-guide.adoc
+++ b/src/docs/asciidoc/dangol-backend-api-guide.adoc
@@ -74,3 +74,31 @@ include::{snippets}/boss/signup/http-response.adoc[]
 === 손님 API
 
 === 가게 API
+==== 1. 가게 등록
+새로운 가게 정보를 등록합니다.
+
+- Request
+include::{snippets}/store/create/http-request.adoc[]
+include::{snippets}/store/create/request-fields.adoc[]
+
+- Response
+include::{snippets}/store/create/http-response.adoc[]
+
+==== 2. 가게 조회
+현재 가게 정보를 조회합니다.
+
+- Request
+include::{snippets}/store/find/http-request.adoc[]
+include::{snippets}/store/find/request-parameters.adoc[]
+
+- Response
+include::{snippets}/store/find/http-response.adoc[]
+
+==== 3. 가게 변경
+가게 정보를 변경합니다.
+
+- Request
+include::{snippets}/store/update/http-request.adoc[]
+include::{snippets}/store/update/request-fields.adoc[]
+- Response
+include::{snippets}/store/update/http-response.adoc[]

--- a/src/test/java/com/dangol/dangolsonnimbackend/store/controller/StoreControllerTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/store/controller/StoreControllerTest.java
@@ -58,7 +58,7 @@ public class StoreControllerTest {
     @Autowired
     private WebApplicationContext context;
 
-    FieldDescriptor[] signUpJsonField = new FieldDescriptor[] {
+    FieldDescriptor[] signUpRequestJsonField = new FieldDescriptor[] {
             fieldWithPath("name").type(JsonFieldType.STRING).description("가게 이름"),
             fieldWithPath("phoneNumber").type(JsonFieldType.STRING).description("가게 전화번호"),
             fieldWithPath("newAddress").type(JsonFieldType.STRING).description("가게 주소"),
@@ -74,7 +74,24 @@ public class StoreControllerTest {
             fieldWithPath("registerName").type(JsonFieldType.STRING).description("가게 사업자명")
     };
 
-    FieldDescriptor[] updateJsonField = new FieldDescriptor[] {
+    FieldDescriptor[] findResponseJsonField = new FieldDescriptor[] {
+            fieldWithPath("id").type(JsonFieldType.NUMBER).description("가게 아이디"),
+            fieldWithPath("name").type(JsonFieldType.STRING).description("가게 이름"),
+//            fieldWithPath("phoneNumber").type(JsonFieldType.STRING).description("가게 전화번호"),
+            fieldWithPath("newAddress").type(JsonFieldType.STRING).description("가게 주소"),
+            fieldWithPath("categoryId").type(JsonFieldType.NUMBER).description("가게 카테고리"),
+            fieldWithPath("comments").type(JsonFieldType.STRING).description("가게 한줄평"),
+            fieldWithPath("sido").type(JsonFieldType.STRING).description("가게 주소 (시/도)"),
+            fieldWithPath("sigungu").type(JsonFieldType.STRING).description("가게 주소 (시/군/구)"),
+            fieldWithPath("bname1").type(JsonFieldType.STRING).description("가게 주소 (읍/면)"),
+            fieldWithPath("bname2").type(JsonFieldType.STRING).description("가게 주소 (동/리)"),
+            fieldWithPath("detailedAddress").type(JsonFieldType.STRING).description("가게 상세주소"),
+//            fieldWithPath("officeHours").type(JsonFieldType.STRING).description("가게 영업시간"),
+            fieldWithPath("registerNumber").type(JsonFieldType.STRING).description("가게 사업자번호"),
+            fieldWithPath("registerName").type(JsonFieldType.STRING).description("가게 사업자명")
+    };
+
+    FieldDescriptor[] updateRequestJsonField = new FieldDescriptor[] {
             fieldWithPath("name").type(JsonFieldType.STRING).optional().description("가게 이름"),
             fieldWithPath("phoneNumber").type(JsonFieldType.STRING).optional().description("가게 전화번호"),
             fieldWithPath("newAddress").type(JsonFieldType.STRING).optional().description("가게 주소"),
@@ -133,9 +150,7 @@ public class StoreControllerTest {
                 .andExpect(jsonPath("$.bname2").value(dto.getBname2()))
                 .andExpect(jsonPath("$.detailedAddress").value(dto.getDetailedAddress()))
                 .andDo(document("store/create",
-                        preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint()),
-                        requestFields(signUpJsonField)
+                        requestFields(signUpRequestJsonField)
                 ));
 
         // 재등록 시에 이미 존재하는 사업자 번호로 반환
@@ -161,11 +176,10 @@ public class StoreControllerTest {
                 .andExpect(jsonPath("$.bname2").value(dto.getBname2()))
                 .andExpect(jsonPath("$.detailedAddress").value(dto.getDetailedAddress()))
                 .andDo(document("store/find",
-                        preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint()),
                         requestParameters(
                                 parameterWithName("id").description("가게 아이디"),
-                                parameterWithName("_csrf").description("CSRF 토큰 정보"))
+                                parameterWithName("_csrf").description("CSRF 토큰 정보")),
+                        responseFields(findResponseJsonField)
 
                 ));
     }
@@ -189,9 +203,7 @@ public class StoreControllerTest {
                 .andExpect(jsonPath("$.name").value(updateDTO.getName().get()))
                 .andExpect(jsonPath("$.sido").value(updateDTO.getSido().get()))
                 .andDo(document("store/update",
-                        preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint()),
-                        requestFields(updateJsonField)
+                        requestFields(updateRequestJsonField)
                 ));
     }
 

--- a/src/test/java/com/dangol/dangolsonnimbackend/store/controller/StoreControllerTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/store/controller/StoreControllerTest.java
@@ -111,7 +111,10 @@ public class StoreControllerTest {
     void setup(RestDocumentationContextProvider restDocumentation) {
         mockMvc = MockMvcBuilders
                 .webAppContextSetup(context)
-                .apply(documentationConfiguration(restDocumentation))
+                .apply(documentationConfiguration(restDocumentation)
+                        .operationPreprocessors()
+                        .withRequestDefaults(prettyPrint())
+                        .withResponseDefaults(prettyPrint()))
                 .build();
 
         dto = StoreSignupRequestDTO.builder()


### PR DESCRIPTION
## Goals
- 가게 API와 관련된 명세서를 작성할 수 있도록 한다.

## Implements
- [x] 테스트에 REST DOCS 관련 설정 추가
- [x] ascii docs 작성  

## Related Issue 
- https://dangol-sonnim.atlassian.net/browse/DS-83

## Test
- "새로운 가게 정보 생성을 요청하면 정상적으로 생성이 된다."
- "특정 가게 아이디 값을 통해 가게를 검색할 수 있다."
- "특정 가게 정보를 업데이트하여 정보를 수정할 수 있다."