### PR TITLE
DS-64 [가게] 카테고리 엔티티 정의 및 설계 (2)

### DIFF
--- a/src/main/java/com/dangol/dangolsonnimbackend/store/domain/Category.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/store/domain/Category.java
@@ -32,4 +32,8 @@ public class Category {
     public void addStore(Store store) {
         this.store.add(store);
     }
+
+    public void removeStore(Store store) {
+        this.store.remove(store);
+    }
 }

--- a/src/main/java/com/dangol/dangolsonnimbackend/store/domain/Store.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/store/domain/Store.java
@@ -55,7 +55,7 @@ public class Store {
     @JoinColumn(name="boss_id")
     private Boss boss;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category")
     @ToString.Exclude
     private Category category;
@@ -84,11 +84,18 @@ public class Store {
 
     public Store(StoreSignupRequestDTO dto, Category category) {
         this(dto);
-        category.addStore(this);
+        this.category = category;
+        this.category.addStore(this);
     }
 
     public void updateName(String name) {
         this.name = name;
+    }
+
+    public void updateCategory(Category category) {
+        this.category.removeStore(this);
+        this.category = category;
+        this.category.addStore(this);
     }
 
     public Optional<Store> update(StoreUpdateDTO dto) {

--- a/src/main/java/com/dangol/dangolsonnimbackend/store/dto/StoreSignupRequestDTO.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/store/dto/StoreSignupRequestDTO.java
@@ -1,5 +1,6 @@
 package com.dangol.dangolsonnimbackend.store.dto;
 
+import com.dangol.dangolsonnimbackend.store.enumeration.CategoryType;
 import lombok.*;
 
 import javax.validation.constraints.NotNull;
@@ -36,6 +37,9 @@ public class StoreSignupRequestDTO {
 
     @NotNull(message = "영업시간은 Null 일 수 없습니다.")
     private String officeHours;
+
+    @NotNull(message = "카테고리는 Null 일 수 없습니다.")
+    private CategoryType categoryType;
 
     @NotNull(message = "사업자번호는 Null 일 수 없습니다.")
     private String registerNumber;

--- a/src/test/java/com/dangol/dangolsonnimbackend/store/controller/StoreControllerTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/store/controller/StoreControllerTest.java
@@ -3,6 +3,7 @@ package com.dangol.dangolsonnimbackend.store.controller;
 import com.dangol.dangolsonnimbackend.errors.BadRequestException;
 import com.dangol.dangolsonnimbackend.store.dto.StoreSignupRequestDTO;
 import com.dangol.dangolsonnimbackend.store.dto.StoreUpdateDTO;
+import com.dangol.dangolsonnimbackend.store.enumeration.CategoryType;
 import com.dangol.dangolsonnimbackend.store.service.StoreService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
@@ -69,6 +70,8 @@ public class StoreControllerTest {
             fieldWithPath("detailedAddress").type(JsonFieldType.STRING).optional().description("가게 상세주소"),
             fieldWithPath("comments").type(JsonFieldType.STRING).description("가게 한줄평"),
             fieldWithPath("officeHours").type(JsonFieldType.STRING).description("가게 영업시간"),
+            // TODO. 카테고리 정보에 대한 비즈니스 로직 구현 완료 시 ignore 삭제
+            fieldWithPath("categoryType").type(JsonFieldType.VARIES).description("카테고리 정보").ignored(),
             fieldWithPath("registerNumber").type(JsonFieldType.STRING).description("가게 사업자번호"),
             fieldWithPath("registerName").type(JsonFieldType.STRING).description("가게 사업자명")
     };
@@ -125,6 +128,7 @@ public class StoreControllerTest {
                 .detailedAddress("")
                 .comments("단골손님 가게로 좋아요.")
                 .officeHours("08:00~10:00")
+                .categoryType(CategoryType.KOREAN)
                 .registerNumber("1234567890")
                 .registerName("단골손님")
                 .build();

--- a/src/test/java/com/dangol/dangolsonnimbackend/store/repository/CategoryRepositoryTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/store/repository/CategoryRepositoryTest.java
@@ -1,0 +1,98 @@
+package com.dangol.dangolsonnimbackend.store.repository;
+
+import com.dangol.dangolsonnimbackend.store.domain.Category;
+import com.dangol.dangolsonnimbackend.store.domain.Store;
+import com.dangol.dangolsonnimbackend.store.dto.StoreSignupRequestDTO;
+import com.dangol.dangolsonnimbackend.store.enumeration.CategoryType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import javax.transaction.Transactional;
+import java.util.Optional;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.linesOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+class CategoryRepositoryTest {
+    @Autowired
+    private StoreRepository storeRepository;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    private Store store;
+
+    private Category category;
+
+    private StoreSignupRequestDTO dto;
+
+    @BeforeEach
+    void setUp() {
+        dto = StoreSignupRequestDTO.builder()
+                .name("단골손님" + new Random().nextInt())
+                .phoneNumber("01012345678")
+                .newAddress("서울특별시 서초구 단골로 130")
+                .sido("서울특별시")
+                .sigungu("서초구")
+                .bname1("단골동")
+                .bname2("")
+                .detailedAddress("")
+                .comments("단골손님 가게로 좋아요.")
+                .officeHours("08:00~10:00")
+                .categoryType(CategoryType.KOREAN)
+                .registerNumber("1234567890")
+                .registerName("단골손님")
+                .build();
+
+        category = new Category();
+        category.setCategoryType(dto.getCategoryType());
+        categoryRepository.save(category);
+
+        store = new Store(dto, category);
+        storeRepository.save(store);
+    }
+
+    @Test
+    @DisplayName("카테고리 정보가 포함되어 생성된 가게는 정상적으로 조회되어야 한다.")
+    void whenCreateNewStore_thenReturnStoreAndCategory() {
+        Optional<Store> store = storeRepository.findById(this.store.getId());
+        Optional<Category> category = categoryRepository.findById(this.store.getCategory().getId());
+
+        assertTrue(store.isPresent());
+        assertTrue(category.isPresent());
+
+        category.ifPresent(found -> {
+            System.out.println(found);
+            System.out.println(found.getStore().size());
+            assertTrue(found.getStore().contains(store.get()));
+        });
+    }
+
+    @Test
+    @DisplayName("카테고리 정보가 포함되어 수정된 가게는 정상적으로 반영되어야 한다.")
+    void whenUpdateStore_thenUpdateCategoryAndCheckCategory() {
+        Optional<Store> store = storeRepository.findById(this.store.getId());
+
+        store.ifPresent(found -> {
+            Category newCategory = new Category();
+            newCategory.setCategoryType(CategoryType.CHINESE);
+            categoryRepository.save(newCategory);
+
+            found.updateCategory(newCategory);
+            storeRepository.save(found);
+        });
+
+        Store updatedStore = storeRepository.getById(this.store.getId());
+        Category updatedCategory = categoryRepository.getById(this.store.getCategory().getId());
+
+        assertThat(updatedStore.getCategory().getCategoryType()).isEqualTo(CategoryType.CHINESE);
+        assertThat(updatedCategory.getStore().contains(updatedStore));
+    }
+}

--- a/src/test/java/com/dangol/dangolsonnimbackend/store/repository/dsl/CategoryQueryRepositoryTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/store/repository/dsl/CategoryQueryRepositoryTest.java
@@ -1,0 +1,36 @@
+package com.dangol.dangolsonnimbackend.store.repository.dsl;
+
+import com.dangol.dangolsonnimbackend.store.domain.Category;
+import com.dangol.dangolsonnimbackend.store.enumeration.CategoryType;
+import com.dangol.dangolsonnimbackend.store.repository.CategoryRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import javax.transaction.Transactional;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+@Transactional
+public class CategoryQueryRepositoryTest {
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private CategoryQueryRepository categoryQueryRepository;
+
+    private Category category;
+
+    @Test
+    @DisplayName("카테고리 테이블에 새로운 카테고리 정보가 추가되면 정상적으로 조회되어야 한다.")
+    void givenSignUpDTO_whenFindById_thenReturnCategory() {
+        category = new Category();
+        category.setCategoryType(CategoryType.KOREAN);
+        categoryRepository.save(category);
+
+        Optional<Category> foundCategory = categoryQueryRepository.findByCategoryType(category.getCategoryType());
+        assertTrue(foundCategory.isPresent());
+    }}


### PR DESCRIPTION
## Goals
- 카테고리 엔티티 관련 작업을 추가로 한다.

## Implements
- [x] 카테고리 관련 헬퍼 메서드 추가
- [x] 카테고리 레포 유닛 테스트 추가
- [x] 테스트 에러 조치 

## Related Issue 
- https://dangol-sonnim.atlassian.net/browse/DS-64

## Test
- "카테고리 테이블에 새로운 카테고리 정보가 추가되면 정상적으로 조회되어야 한다."
- "카테고리 정보가 포함되어 생성된 가게는 정상적으로 조회되어야 한다."
- "카테고리 정보가 포함되어 수정된 가게는 정상적으로 반영되어야 한다."