### PR TITLE
DS-90 [구독권] 구독권 조회하기 API 추가

### DIFF
--- a/src/docs/asciidoc/dangol-backend-api-guide.adoc
+++ b/src/docs/asciidoc/dangol-backend-api-guide.adoc
@@ -158,6 +158,7 @@ include::{snippets}/store/update/http-response.adoc[]
 
 === 구독권 API
 새로운 구독권을 등록합니다.
+==== 1. 구독권 등록
 
 - Request
 include::{snippets}/subscribe/create/http-request.adoc[]
@@ -165,3 +166,11 @@ include::{snippets}/subscribe/create/request-fields.adoc[]
 
 - Response
 include::{snippets}/subscribe/create/http-response.adoc[]
+==== 2. 구독권 조회
+
+- Request
+include::{snippets}/subscribe/get/http-request.adoc[]
+include::{snippets}/subscribe/get/path-parameters.adoc[]
+
+- Response
+include::{snippets}/subscribe/get/http-response.adoc[]

--- a/src/main/java/com/dangol/dangolsonnimbackend/subscribe/controller/SubscribeController.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/subscribe/controller/SubscribeController.java
@@ -5,10 +5,7 @@ import com.dangol.dangolsonnimbackend.subscribe.dto.SubscribeResponseDTO;
 import com.dangol.dangolsonnimbackend.subscribe.service.SubscribeService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
@@ -27,5 +24,11 @@ public class SubscribeController {
     public ResponseEntity<SubscribeResponseDTO> create(@Valid @RequestBody SubscribeRequestDTO dto) {
         SubscribeResponseDTO responseDTO = subscribeService.create(dto);
         return ResponseEntity.status(HttpStatus.CREATED).body(responseDTO);
+    }
+
+    @GetMapping("/{subscribeId}")
+    public ResponseEntity<SubscribeResponseDTO> getSubscribe(@PathVariable Long subscribeId){
+        SubscribeResponseDTO responseDTO = subscribeService.getSubscribe(subscribeId);
+        return ResponseEntity.status(HttpStatus.OK).body(responseDTO);
     }
 }

--- a/src/main/java/com/dangol/dangolsonnimbackend/subscribe/domain/Subscribe.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/subscribe/domain/Subscribe.java
@@ -1,7 +1,6 @@
 package com.dangol.dangolsonnimbackend.subscribe.domain;
 
 import com.dangol.dangolsonnimbackend.store.domain.Store;
-import com.dangol.dangolsonnimbackend.subscribe.dto.SubscribeRequestDTO;
 import com.dangol.dangolsonnimbackend.subscribe.dto.SubscribeResponseDTO;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;

--- a/src/main/java/com/dangol/dangolsonnimbackend/subscribe/service/SubscribeService.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/subscribe/service/SubscribeService.java
@@ -8,4 +8,6 @@ import com.dangol.dangolsonnimbackend.subscribe.dto.SubscribeResponseDTO;
 public interface SubscribeService {
     SubscribeResponseDTO create(SubscribeRequestDTO dto);
     Subscribe classify(SubscribeRequestDTO dto, Store store);
+
+    SubscribeResponseDTO getSubscribe(Long subscribeId);
 }

--- a/src/main/java/com/dangol/dangolsonnimbackend/subscribe/service/impl/SubscribeServiceImpl.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/subscribe/service/impl/SubscribeServiceImpl.java
@@ -1,6 +1,7 @@
 package com.dangol.dangolsonnimbackend.subscribe.service.impl;
 
 import com.dangol.dangolsonnimbackend.errors.BadRequestException;
+import com.dangol.dangolsonnimbackend.errors.NotFoundException;
 import com.dangol.dangolsonnimbackend.errors.enumeration.ErrorCodeMessage;
 import com.dangol.dangolsonnimbackend.store.domain.Store;
 import com.dangol.dangolsonnimbackend.store.repository.StoreRepository;
@@ -58,5 +59,12 @@ public class SubscribeServiceImpl implements SubscribeService {
             default:
                 throw new BadRequestException(ErrorCodeMessage.INVALID_SUBSCRIBE_TYPE);
         }
+    }
+
+    @Transactional(readOnly = true)
+    public SubscribeResponseDTO getSubscribe(Long subscribeId) {
+        return subscribeRepository.findById(subscribeId).orElseThrow(
+                () -> new NotFoundException(ErrorCodeMessage.SUBSCRIBE_NOT_FOUND)
+        ).toResponseDTO();
     }
 }

--- a/src/test/java/com/dangol/dangolsonnimbackend/subscribe/controller/SubscribeControllerTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/subscribe/controller/SubscribeControllerTest.java
@@ -64,8 +64,6 @@ class SubscribeControllerTest {
     @Autowired
     private SubscribeService subscribeService;
     private SubscribeRequestDTO subscribeRequestDTO;
-    private Long storeId;
-    private List<BenefitDTO> benefitDTOList;
 
     @BeforeEach
     void setup(RestDocumentationContextProvider restDocumentation){
@@ -94,7 +92,7 @@ class SubscribeControllerTest {
                 .categoryType(CategoryType.KOREAN)
                 .build();
 
-        benefitDTOList = List.of(
+        List<BenefitDTO> benefitDTOList = List.of(
                 new BenefitDTO("Benefit 1"),
                 new BenefitDTO("Benefit 2"),
                 new BenefitDTO("Benefit 3")
@@ -104,7 +102,7 @@ class SubscribeControllerTest {
         category.setCategoryType(CategoryType.KOREAN);
         categoryRepository.save(category);
 
-        storeId = storeService.signup(signupRequestDTO).getId();
+        Long storeId = storeService.signup(signupRequestDTO).getId();
 
         subscribeRequestDTO = SubscribeRequestDTO.builder()
                 .isTop(true)

--- a/src/test/java/com/dangol/dangolsonnimbackend/subscribe/controller/SubscribeControllerTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/subscribe/controller/SubscribeControllerTest.java
@@ -7,6 +7,8 @@ import com.dangol.dangolsonnimbackend.store.repository.CategoryRepository;
 import com.dangol.dangolsonnimbackend.store.service.StoreService;
 import com.dangol.dangolsonnimbackend.subscribe.dto.BenefitDTO;
 import com.dangol.dangolsonnimbackend.subscribe.dto.SubscribeRequestDTO;
+import com.dangol.dangolsonnimbackend.subscribe.dto.SubscribeResponseDTO;
+import com.dangol.dangolsonnimbackend.subscribe.service.SubscribeService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -17,6 +19,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -34,6 +37,8 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 
@@ -54,9 +59,13 @@ class SubscribeControllerTest {
     @Autowired
     private CategoryRepository categoryRepository;
     private static final String BASE_URL = "/api/v1/subscribe";
-    private StoreSignupRequestDTO signupRequestDTO;
     @Autowired
     private StoreService storeService;
+    @Autowired
+    private SubscribeService subscribeService;
+    private SubscribeRequestDTO subscribeRequestDTO;
+    private Long storeId;
+    private List<BenefitDTO> benefitDTOList;
 
     @BeforeEach
     void setup(RestDocumentationContextProvider restDocumentation){
@@ -69,7 +78,7 @@ class SubscribeControllerTest {
                         .withResponseDefaults(prettyPrint()))
                 .build();
 
-        signupRequestDTO = StoreSignupRequestDTO.builder()
+        StoreSignupRequestDTO signupRequestDTO = StoreSignupRequestDTO.builder()
                 .name("단골손님" + new Random().nextInt())
                 .phoneNumber("01012345678")
                 .newAddress("서울특별시 서초구 단골로 130")
@@ -84,12 +93,8 @@ class SubscribeControllerTest {
                 .registerName("단골손님")
                 .categoryType(CategoryType.KOREAN)
                 .build();
-    }
 
-    @Test
-    void givenSubscribeRequestDTO_whenCreate_thenReturnSubscribeResponseDTO() throws Exception {
-
-        List<BenefitDTO> benefitDTOList = List.of(
+        benefitDTOList = List.of(
                 new BenefitDTO("Benefit 1"),
                 new BenefitDTO("Benefit 2"),
                 new BenefitDTO("Benefit 3")
@@ -99,8 +104,9 @@ class SubscribeControllerTest {
         category.setCategoryType(CategoryType.KOREAN);
         categoryRepository.save(category);
 
-        Long storeId = storeService.signup(signupRequestDTO).getId();
-        SubscribeRequestDTO subscribeRequestDTO = SubscribeRequestDTO.builder()
+        storeId = storeService.signup(signupRequestDTO).getId();
+
+        subscribeRequestDTO = SubscribeRequestDTO.builder()
                 .isTop(true)
                 .useCount(5)
                 .type(COUNT)
@@ -110,6 +116,10 @@ class SubscribeControllerTest {
                 .name("NAME TEST")
                 .benefits(benefitDTOList)
                 .build();
+    }
+
+    @Test
+    void givenSubscribeRequestDTO_whenCreate_thenReturnSubscribeResponseDTO() throws Exception {
 
         mockMvc.perform(post(BASE_URL)
                 .with(csrf())
@@ -154,5 +164,44 @@ class SubscribeControllerTest {
                                 fieldWithPath("benefits[].description").type(JsonFieldType.STRING).description("구독권 혜택")
                         )
                 ));
+    }
+
+    @Test
+    void givenSubscribeId_whenGetSubscribe_thenReturnSubscribeResponseDTO() throws Exception{
+        SubscribeResponseDTO subscribeResponseDTO = subscribeService.create(subscribeRequestDTO);
+
+        mockMvc.perform(RestDocumentationRequestBuilders.get(BASE_URL + "/{subscribeId}", subscribeResponseDTO.getSubscribeId())
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.subscribeId").exists())
+                .andExpect(jsonPath("$.type").value(subscribeRequestDTO.getType().toString()))
+                .andExpect(jsonPath("$.name").value(subscribeRequestDTO.getName()))
+                .andExpect(jsonPath("$.price").value(subscribeRequestDTO.getPrice()))
+                .andExpect(jsonPath("$.storeId").value(subscribeRequestDTO.getStoreId()))
+                .andExpect(jsonPath("$.intro").value(subscribeRequestDTO.getIntro()))
+                .andExpect(jsonPath("$.isTop").value(subscribeRequestDTO.getIsTop()))
+                .andExpect(jsonPath("$.useCount").value(subscribeRequestDTO.getUseCount()))
+                .andExpect(jsonPath("$.createAt").exists())
+                .andExpect(jsonPath("$.modifiedAt").exists())
+                .andExpect(jsonPath("$.benefits.[0].description").value(subscribeRequestDTO.getBenefits().get(0).getDescription()))
+                .andExpect(jsonPath("$.benefits.[1].description").value(subscribeRequestDTO.getBenefits().get(1).getDescription()))
+                .andExpect(jsonPath("$.benefits.[2].description").value(subscribeRequestDTO.getBenefits().get(2).getDescription()))
+                .andDo(document("subscribe/get",
+                        pathParameters(
+                                parameterWithName("subscribeId").description("구독권 아이디")
+                        ),
+                        responseFields(
+                                fieldWithPath("subscribeId").type(JsonFieldType.NUMBER).description("구독권 아이디"),
+                                fieldWithPath("type").type(JsonFieldType.STRING).description("구독권 타입"),
+                                fieldWithPath("name").type(JsonFieldType.STRING).description("구독권 이름"),
+                                fieldWithPath("price").type(JsonFieldType.NUMBER).description("구독권 가격"),
+                                fieldWithPath("storeId").type(JsonFieldType.NUMBER).description("구독권 가게 아이디"),
+                                fieldWithPath("intro").type(JsonFieldType.STRING).description("구독권 간단소개"),
+                                fieldWithPath("isTop").type(JsonFieldType.BOOLEAN).description("구독권 대표 여부"),
+                                fieldWithPath("useCount").type(JsonFieldType.NUMBER).description("구독권 사용가능 횟수"),
+                                fieldWithPath("createAt").type(JsonFieldType.STRING).description("구독권 생성날짜"),
+                                fieldWithPath("modifiedAt").type(JsonFieldType.STRING).description("구독권 수정날짜"),
+                                fieldWithPath("benefits[].description").type(JsonFieldType.STRING).description("구독권 혜택")
+                        )));
     }
 }


### PR DESCRIPTION
## Goals
- 구독권 조회하는 API를 추가합니다

## Implements
- [x] 구독권 조회 서비스 추가
- [x] 구독권 조회 API 추가
- [x] 구독권 조회 API 명세 추가  

## Related Issue 
- https://dangol-sonnim.atlassian.net/browse/DS-90

## Test
- givenSubscribeId_whenGetSubscribe_thenReturnSubscribeResponseDTO

