### PR TITLE
DS-88 [가게] 카테고리 관련 서비스 설계

### DIFF
--- a/src/main/java/com/dangol/dangolsonnimbackend/store/controller/StoreController.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/store/controller/StoreController.java
@@ -30,8 +30,8 @@ public class StoreController {
     }
 
     @PostMapping("/create")
-    public ResponseEntity<StoreResponseDTO> signup(@Valid @RequestBody StoreSignupRequestDTO dto) {
-        StoreResponseDTO res = storeService.signup(dto);
+    public ResponseEntity<StoreResponseDTO> create(@Valid @RequestBody StoreSignupRequestDTO dto) {
+        StoreResponseDTO res = storeService.create(dto);
 
         return ResponseEntity
                 .status(HttpStatus.CREATED)

--- a/src/main/java/com/dangol/dangolsonnimbackend/store/domain/Category.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/store/domain/Category.java
@@ -29,6 +29,10 @@ public class Category {
     @ToString.Exclude
     private List<Store> store = new ArrayList<>();
 
+    public Category(CategoryType categoryType) {
+        this.categoryType = categoryType;
+    }
+
     public void addStore(Store store) {
         this.store.add(store);
     }

--- a/src/main/java/com/dangol/dangolsonnimbackend/store/domain/Store.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/store/domain/Store.java
@@ -55,7 +55,7 @@ public class Store {
     @JoinColumn(name="boss_id")
     private Boss boss;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "category")
     @ToString.Exclude
     private Category category;
@@ -98,7 +98,7 @@ public class Store {
         this.category.addStore(this);
     }
 
-    public Optional<Store> update(StoreUpdateDTO dto) {
+    public Optional<Store> update(StoreUpdateDTO dto, Optional<Category> category) {
         dto.getName().ifPresent(name -> this.name = name);
         dto.getPhoneNumber().ifPresent(phoneNumber -> this.phoneNumber = phoneNumber);
         dto.getNewAddress().ifPresent(newAddress -> this.newAddress = newAddress);
@@ -110,6 +110,7 @@ public class Store {
         dto.getComments().ifPresent(comments -> this.comments = comments);
         dto.getOfficeHours().ifPresent(officeHours -> this.officeHours = officeHours);
         dto.getRegisterName().ifPresent(registerName -> this.registerName = registerName);
+        category.ifPresent(newCategory -> updateCategory(newCategory));
 
         return Optional.of(this);
     }

--- a/src/main/java/com/dangol/dangolsonnimbackend/store/dto/StoreResponseDTO.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/store/dto/StoreResponseDTO.java
@@ -1,6 +1,8 @@
 package com.dangol.dangolsonnimbackend.store.dto;
 
+import com.dangol.dangolsonnimbackend.store.domain.Category;
 import com.dangol.dangolsonnimbackend.store.domain.Store;
+import com.dangol.dangolsonnimbackend.store.enumeration.CategoryType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -33,6 +35,8 @@ public class StoreResponseDTO {
 
     private String registerName;
 
+    private CategoryType categoryType;
+
     // TODO. 태그 및 이미지 필드 추가
 
     public StoreResponseDTO(Store store) {
@@ -47,5 +51,6 @@ public class StoreResponseDTO {
         this.detailedAddress = store.getDetailedAddress();
         this.registerNumber = store.getRegisterNumber();
         this.registerName = store.getRegisterName();
+        this.categoryType = store.getCategory().getCategoryType();
     }
 }

--- a/src/main/java/com/dangol/dangolsonnimbackend/store/dto/StoreUpdateDTO.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/store/dto/StoreUpdateDTO.java
@@ -1,6 +1,9 @@
 package com.dangol.dangolsonnimbackend.store.dto;
 
-import lombok.*;
+import com.dangol.dangolsonnimbackend.store.enumeration.CategoryType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
 
 import javax.validation.constraints.NotNull;
 import java.util.Optional;
@@ -34,6 +37,8 @@ public class StoreUpdateDTO {
 
     private Optional<String> registerName = Optional.empty();
 
+    private Optional<CategoryType> categoryType = Optional.empty();
+
     private StoreUpdateDTO() { }
 
     public StoreUpdateDTO(String registerNumber) {
@@ -52,4 +57,5 @@ public class StoreUpdateDTO {
     public StoreUpdateDTO officeHours(String officeHours) { this.officeHours = Optional.of(officeHours); return this; }
     public StoreUpdateDTO registerNumber(String registerNumber) { this.registerNumber = registerNumber; return this; }
     public StoreUpdateDTO registerName(String registerName) { this.registerName = Optional.of(registerName); return this; }
+    public StoreUpdateDTO categoryType(CategoryType categoryType) { this.categoryType = Optional.of(categoryType); return this; }
 }

--- a/src/main/java/com/dangol/dangolsonnimbackend/store/service/StoreService.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/store/service/StoreService.java
@@ -5,7 +5,7 @@ import com.dangol.dangolsonnimbackend.store.dto.StoreSignupRequestDTO;
 import com.dangol.dangolsonnimbackend.store.dto.StoreUpdateDTO;
 
 public interface StoreService {
-    StoreResponseDTO signup(StoreSignupRequestDTO dto);
+    StoreResponseDTO create(StoreSignupRequestDTO dto);
     StoreResponseDTO findById(Long id);
     StoreResponseDTO updateStoreByDto(StoreUpdateDTO dto);
 }

--- a/src/test/java/com/dangol/dangolsonnimbackend/store/service/StoreServiceTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/store/service/StoreServiceTest.java
@@ -1,8 +1,11 @@
 package com.dangol.dangolsonnimbackend.store.service;
 
+import com.dangol.dangolsonnimbackend.store.domain.Category;
 import com.dangol.dangolsonnimbackend.store.dto.StoreResponseDTO;
 import com.dangol.dangolsonnimbackend.store.dto.StoreSignupRequestDTO;
 import com.dangol.dangolsonnimbackend.store.dto.StoreUpdateDTO;
+import com.dangol.dangolsonnimbackend.store.enumeration.CategoryType;
+import com.dangol.dangolsonnimbackend.store.repository.CategoryRepository;
 import com.dangol.dangolsonnimbackend.store.repository.StoreRepository;
 import com.dangol.dangolsonnimbackend.store.repository.dsl.StoreQueryRepository;
 import com.dangol.dangolsonnimbackend.store.service.impl.StoreServiceImpl;
@@ -22,13 +25,13 @@ import static org.junit.jupiter.api.Assertions.*;
 @Transactional
 public class StoreServiceTest {
     @Autowired
-    private StoreRepository storeRepository;
-
-    @Autowired
     private StoreQueryRepository storeQueryRepository;
 
     @Autowired
     private StoreServiceImpl storeService;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
 
     private StoreSignupRequestDTO dto;
 
@@ -47,22 +50,27 @@ public class StoreServiceTest {
                 .officeHours("08:00~10:00")
                 .registerNumber("1234567890")
                 .registerName("단골손님")
+                .categoryType(CategoryType.KOREAN)
                 .build();
+
+        categoryRepository.saveAndFlush(new Category(CategoryType.KOREAN));
+        categoryRepository.saveAndFlush(new Category(CategoryType.CHINESE));
     }
 
     @Test
     @DisplayName("새로운 가게 정보를 전달받으면 가게를 생성하도록 한다.")
     public void givenRequestDto_whenSignup_thenSaveStore() {
-        StoreResponseDTO response = storeService.signup(dto);
+        StoreResponseDTO response = storeService.create(dto);
 
         assertEquals(response.getName(), dto.getName());
         assertEquals(response.getNewAddress(), dto.getNewAddress());
+        assertEquals(response.getCategoryType(), dto.getCategoryType());
     }
 
     @Test
     @DisplayName("가게 ID 값을 전달받으면 가게를 정상적으로 조회할 수 있다")
     public void givenStoreId_whenFindById_thenReturnStore() {
-        StoreResponseDTO response = storeService.signup(dto);
+        StoreResponseDTO response = storeService.create(dto);
 
         assertTrue(storeQueryRepository.findById(response.getId()).isPresent());
     }
@@ -70,17 +78,19 @@ public class StoreServiceTest {
     @Test
     @DisplayName("수정할 가게 정보를 전달받으면 가게를 수정하도록 한다.")
     public void givenUpdateDto_whenFindByRegisterNumber_thenUpdateStore() {
-        storeService.signup(dto);
+        storeService.create(dto);
 
         StoreUpdateDTO updateDto =
                 new StoreUpdateDTO(dto.getRegisterNumber())
                         .name("단골손님" + new Random().nextInt())
-                        .sido("부산광역시");
+                        .sido("부산광역시")
+                        .categoryType(CategoryType.CHINESE);
 
         StoreResponseDTO response = storeService.updateStoreByDto(updateDto);
 
         assertNotEquals(dto.getName(), storeQueryRepository.findById(response.getId()).get().getName());
         assertNotEquals(dto.getSido(), storeQueryRepository.findById(response.getId()).get().getSido());
+        assertEquals(CategoryType.CHINESE, response.getCategoryType());
     }
 
 }


### PR DESCRIPTION
## Goals
- 카테고리 관련 서비스를 구현한다.

## Implements
- [x] 요청과 응답 관련 DTO에 카테고리 필드 추가
- [x] 가게와 카테고리 엔티티에 Cascade 옵션과 생성자 추가
- [x] 컨트롤러 메서드 네이밍 일부 수정
- [x] 가게 서비스 단위 테스트 추가 

## Related Issue 
- https://dangol-sonnim.atlassian.net/browse/DS-88

## Test
- "새로운 가게 정보 생성을 요청하면 정상적으로 생성이 된다."
- "특정 가게 아이디 값을 통해 가게를 검색할 수 있다."
- "특정 가게 정보를 업데이트하여 정보를 수정할 수 있다."