### PR TITLE
DS-91 [가게] 태그 추가

### DIFF
--- a/src/main/java/com/dangol/dangolsonnimbackend/store/domain/Store.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/store/domain/Store.java
@@ -6,7 +6,9 @@ import com.dangol.dangolsonnimbackend.store.dto.StoreUpdateDTO;
 import lombok.*;
 
 import javax.persistence.*;
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 
 @Entity
 @Getter
@@ -67,6 +69,14 @@ public class Store {
     @Column(nullable = false)
     private String registerName;
 
+    @ManyToMany
+    @JoinTable(
+            name = "store_tag",
+            joinColumns = @JoinColumn(name = "store_id"),
+            inverseJoinColumns = @JoinColumn(name = "tag_id")
+    )
+    private Set<Tag> tags = new HashSet<>();
+
     public Store(StoreSignupRequestDTO dto) {
         this.name = dto.getName();
         this.phoneNumber = dto.getPhoneNumber();
@@ -113,5 +123,10 @@ public class Store {
         category.ifPresent(newCategory -> updateCategory(newCategory));
 
         return Optional.of(this);
+    }
+
+    public void setTags(Set<Tag> tags){
+        this.tags.clear();
+        this.tags = tags;
     }
 }

--- a/src/main/java/com/dangol/dangolsonnimbackend/store/domain/Tag.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/store/domain/Tag.java
@@ -1,0 +1,26 @@
+package com.dangol.dangolsonnimbackend.store.domain;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.*;
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@Table(name = "tb_tag")
+public class Tag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @ManyToMany(mappedBy = "tags")
+    private Set<Store> stores = new HashSet<>();
+}

--- a/src/main/java/com/dangol/dangolsonnimbackend/store/dto/StoreResponseDTO.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/store/dto/StoreResponseDTO.java
@@ -1,12 +1,16 @@
 package com.dangol.dangolsonnimbackend.store.dto;
 
-import com.dangol.dangolsonnimbackend.store.domain.Category;
 import com.dangol.dangolsonnimbackend.store.domain.Store;
+import com.dangol.dangolsonnimbackend.store.domain.Tag;
 import com.dangol.dangolsonnimbackend.store.enumeration.CategoryType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Getter
 @Setter
@@ -36,6 +40,7 @@ public class StoreResponseDTO {
     private String registerName;
 
     private CategoryType categoryType;
+    private List<String> tags;
 
     // TODO. 태그 및 이미지 필드 추가
 
@@ -52,5 +57,6 @@ public class StoreResponseDTO {
         this.registerNumber = store.getRegisterNumber();
         this.registerName = store.getRegisterName();
         this.categoryType = store.getCategory().getCategoryType();
+        this.tags = store.getTags().stream().map(Tag::getName).collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/dangol/dangolsonnimbackend/store/dto/StoreSignupRequestDTO.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/store/dto/StoreSignupRequestDTO.java
@@ -4,6 +4,7 @@ import com.dangol.dangolsonnimbackend.store.enumeration.CategoryType;
 import lombok.*;
 
 import javax.validation.constraints.NotNull;
+import java.util.List;
 
 @Getter
 @Setter
@@ -46,5 +47,7 @@ public class StoreSignupRequestDTO {
 
     @NotNull(message = "사업자명은 Null 일 수 없습니다.")
     private String registerName;
+
+    private List<String> tags;
 
 }

--- a/src/main/java/com/dangol/dangolsonnimbackend/store/dto/StoreUpdateDTO.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/store/dto/StoreUpdateDTO.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.Setter;
 
 import javax.validation.constraints.NotNull;
+import java.util.List;
 import java.util.Optional;
 
 @Getter
@@ -38,6 +39,8 @@ public class StoreUpdateDTO {
     private Optional<String> registerName = Optional.empty();
 
     private Optional<CategoryType> categoryType = Optional.empty();
+
+    private List<String> tags;
 
     private StoreUpdateDTO() { }
 

--- a/src/main/java/com/dangol/dangolsonnimbackend/store/repository/TagRepository.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/store/repository/TagRepository.java
@@ -1,0 +1,7 @@
+package com.dangol.dangolsonnimbackend.store.repository;
+
+import com.dangol.dangolsonnimbackend.store.domain.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TagRepository extends JpaRepository<Tag, Long> {
+}

--- a/src/main/java/com/dangol/dangolsonnimbackend/store/repository/dsl/TagQueryRepository.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/store/repository/dsl/TagQueryRepository.java
@@ -1,0 +1,24 @@
+package com.dangol.dangolsonnimbackend.store.repository.dsl;
+
+import com.dangol.dangolsonnimbackend.store.domain.QTag;
+import com.dangol.dangolsonnimbackend.store.domain.Tag;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Repository
+public class TagQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public Optional<Tag> findByName(String name) {
+        return Optional.ofNullable(
+                queryFactory.selectFrom(QTag.tag)
+                        .where(QTag.tag.name.eq(name))
+                        .fetchOne());
+    }
+
+}

--- a/src/main/java/com/dangol/dangolsonnimbackend/store/service/TagService.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/store/service/TagService.java
@@ -1,0 +1,10 @@
+package com.dangol.dangolsonnimbackend.store.service;
+
+import com.dangol.dangolsonnimbackend.store.domain.Tag;
+
+import java.util.List;
+import java.util.Set;
+
+public interface TagService {
+    Set<Tag> getOrCreateTags(List<String> tagNames);
+}

--- a/src/main/java/com/dangol/dangolsonnimbackend/store/service/impl/StoreServiceImpl.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/store/service/impl/StoreServiceImpl.java
@@ -8,7 +8,6 @@ import com.dangol.dangolsonnimbackend.store.domain.Store;
 import com.dangol.dangolsonnimbackend.store.dto.StoreResponseDTO;
 import com.dangol.dangolsonnimbackend.store.dto.StoreSignupRequestDTO;
 import com.dangol.dangolsonnimbackend.store.dto.StoreUpdateDTO;
-import com.dangol.dangolsonnimbackend.store.enumeration.CategoryType;
 import com.dangol.dangolsonnimbackend.store.repository.StoreRepository;
 import com.dangol.dangolsonnimbackend.store.repository.dsl.CategoryQueryRepository;
 import com.dangol.dangolsonnimbackend.store.repository.dsl.StoreQueryRepository;
@@ -25,12 +24,14 @@ public class StoreServiceImpl implements StoreService {
     private final StoreRepository storeRepository;
     private final StoreQueryRepository storeQueryRepository;
     private final CategoryQueryRepository categoryQueryRepository;
+    private final TagServiceImpl tagService;
 
     @Autowired
-    public StoreServiceImpl(StoreRepository storeRepository, StoreQueryRepository storeQueryRepository, CategoryQueryRepository categoryQueryRepository) {
+    public StoreServiceImpl(StoreRepository storeRepository, StoreQueryRepository storeQueryRepository, CategoryQueryRepository categoryQueryRepository, TagServiceImpl tagService) {
         this.storeRepository = storeRepository;
         this.storeQueryRepository = storeQueryRepository;
         this.categoryQueryRepository = categoryQueryRepository;
+        this.tagService = tagService;
     }
 
     /**
@@ -51,6 +52,9 @@ public class StoreServiceImpl implements StoreService {
 
         Store store = new Store(dto, category);
         storeRepository.save(store);
+
+        // 태그를 추가해주는 과정입니다.
+        store.setTags(tagService.getOrCreateTags(dto.getTags()));
 
         return new StoreResponseDTO(store);
     }
@@ -86,6 +90,10 @@ public class StoreServiceImpl implements StoreService {
 
         if(store.isEmpty())
             throw new BadRequestException(ErrorCodeMessage.STORE_NOT_FOUND);
+
+        if (dto.getTags() != null && !dto.getTags().isEmpty()) {
+            store.get().setTags(tagService.getOrCreateTags(dto.getTags()));
+        }
 
         return store
                 .filter(o -> o.getRegisterNumber() != null)

--- a/src/main/java/com/dangol/dangolsonnimbackend/store/service/impl/TagServiceImpl.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/store/service/impl/TagServiceImpl.java
@@ -1,0 +1,41 @@
+package com.dangol.dangolsonnimbackend.store.service.impl;
+
+import com.dangol.dangolsonnimbackend.store.domain.Tag;
+import com.dangol.dangolsonnimbackend.store.repository.TagRepository;
+import com.dangol.dangolsonnimbackend.store.repository.dsl.TagQueryRepository;
+import com.dangol.dangolsonnimbackend.store.service.TagService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+
+@Service
+@Transactional
+public class TagServiceImpl implements TagService{
+
+    private final TagQueryRepository tagQueryRepository;
+    private final TagRepository tagRepository;
+
+    public TagServiceImpl(TagQueryRepository tagQueryRepository, TagRepository tagRepository) {
+        this.tagQueryRepository = tagQueryRepository;
+        this.tagRepository = tagRepository;
+    }
+
+
+    public Set<Tag> getOrCreateTags(List<String> tagNames) {
+        Set<Tag> tags = new HashSet<>();
+        for (String tagName : tagNames) {
+            Tag tag = tagQueryRepository.findByName(tagName)
+                    .orElseGet(() -> {
+                        Tag newTag = new Tag();
+                        newTag.setName(tagName);
+                        return tagRepository.save(newTag);
+                    });
+            tags.add(tag);
+        }
+        return tags;
+    }
+}

--- a/src/test/java/com/dangol/dangolsonnimbackend/store/controller/StoreControllerTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/store/controller/StoreControllerTest.java
@@ -26,6 +26,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 import javax.transaction.Transactional;
+import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 
@@ -77,7 +78,8 @@ public class StoreControllerTest {
             fieldWithPath("officeHours").type(JsonFieldType.STRING).description("가게 영업시간"),
             fieldWithPath("categoryType").type(JsonFieldType.VARIES).description("카테고리 정보"),
             fieldWithPath("registerNumber").type(JsonFieldType.STRING).description("가게 사업자번호"),
-            fieldWithPath("registerName").type(JsonFieldType.STRING).description("가게 사업자명")
+            fieldWithPath("registerName").type(JsonFieldType.STRING).description("가게 사업자명"),
+            fieldWithPath("tags").type(JsonFieldType.ARRAY).description("가게 태그")
     };
 
     FieldDescriptor[] findResponseJsonField = new FieldDescriptor[] {
@@ -94,7 +96,8 @@ public class StoreControllerTest {
 //            fieldWithPath("officeHours").type(JsonFieldType.STRING).description("가게 영업시간"),
             fieldWithPath("categoryType").type(JsonFieldType.VARIES).description("카테고리 정보"),
             fieldWithPath("registerNumber").type(JsonFieldType.STRING).description("가게 사업자번호"),
-            fieldWithPath("registerName").type(JsonFieldType.STRING).description("가게 사업자명")
+            fieldWithPath("registerName").type(JsonFieldType.STRING).description("가게 사업자명"),
+            fieldWithPath("tags").type(JsonFieldType.ARRAY).description("가게 태그")
     };
 
     FieldDescriptor[] updateRequestJsonField = new FieldDescriptor[] {
@@ -110,7 +113,8 @@ public class StoreControllerTest {
             fieldWithPath("officeHours").type(JsonFieldType.STRING).optional().description("가게 영업시간"),
             fieldWithPath("categoryType").type(JsonFieldType.VARIES).description("카테고리 정보"),
             fieldWithPath("registerNumber").type(JsonFieldType.STRING).description("가게 사업자번호"),
-            fieldWithPath("registerName").type(JsonFieldType.STRING).optional().description("가게 사업자명")
+            fieldWithPath("registerName").type(JsonFieldType.STRING).optional().description("가게 사업자명"),
+            fieldWithPath("tags").type(JsonFieldType.ARRAY).description("가게 태그")
     };
 
     @BeforeEach
@@ -137,6 +141,7 @@ public class StoreControllerTest {
                 .categoryType(CategoryType.KOREAN)
                 .registerNumber("1234567890")
                 .registerName("단골손님")
+                .tags(List.of("태그1", "태그2"))
                 .build();
 
         categoryRepository.saveAndFlush(new Category(CategoryType.KOREAN));
@@ -160,6 +165,8 @@ public class StoreControllerTest {
                 .andExpect(jsonPath("$.bname2").value(dto.getBname2()))
                 .andExpect(jsonPath("$.detailedAddress").value(dto.getDetailedAddress()))
                 .andExpect(jsonPath("$.categoryType").value(dto.getCategoryType().toString()))
+                .andExpect(jsonPath("$.tags[0]").value(dto.getTags().get(0)))
+                .andExpect(jsonPath("$.tags[1]").value(dto.getTags().get(1)))
                 .andDo(document("store/create",
                         requestFields(signUpRequestJsonField)
                 ));
@@ -186,6 +193,8 @@ public class StoreControllerTest {
                 .andExpect(jsonPath("$.bname2").value(dto.getBname2()))
                 .andExpect(jsonPath("$.detailedAddress").value(dto.getDetailedAddress()))
                 .andExpect(jsonPath("$.categoryType").value(dto.getCategoryType().toString()))
+                .andExpect(jsonPath("$.tags[0]").value(dto.getTags().get(0)))
+                .andExpect(jsonPath("$.tags[1]").value(dto.getTags().get(1)))
                 .andDo(document("store/find",
                         requestParameters(
                                 parameterWithName("id").description("가게 아이디"),
@@ -206,6 +215,7 @@ public class StoreControllerTest {
         updateDTO.setName(Optional.of("단골손님" + new Random().nextInt()));
         updateDTO.setSido(Optional.of("경기도"));
         updateDTO.setCategoryType(Optional.of(CategoryType.CHINESE));
+        updateDTO.setTags(List.of("변경 태그1"));
 
         mockMvc.perform(patch("/api/v1/store/update")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -215,6 +225,7 @@ public class StoreControllerTest {
                 .andExpect(jsonPath("$.name").value(updateDTO.getName().get()))
                 .andExpect(jsonPath("$.sido").value(updateDTO.getSido().get()))
                 .andExpect(jsonPath("$.categoryType").value(updateDTO.getCategoryType().get().toString()))
+                .andExpect(jsonPath("$.tags[0]").value(updateDTO.getTags().get(0)))
                 .andDo(document("store/update",
                         requestFields(updateRequestJsonField)
                 ));

--- a/src/test/java/com/dangol/dangolsonnimbackend/store/controller/StoreControllerTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/store/controller/StoreControllerTest.java
@@ -165,8 +165,8 @@ public class StoreControllerTest {
                 .andExpect(jsonPath("$.bname2").value(dto.getBname2()))
                 .andExpect(jsonPath("$.detailedAddress").value(dto.getDetailedAddress()))
                 .andExpect(jsonPath("$.categoryType").value(dto.getCategoryType().toString()))
-                .andExpect(jsonPath("$.tags[0]").value(dto.getTags().get(0)))
-                .andExpect(jsonPath("$.tags[1]").value(dto.getTags().get(1)))
+                .andExpect(jsonPath("$.tags[0]").exists())
+                .andExpect(jsonPath("$.tags[1]").exists())
                 .andDo(document("store/create",
                         requestFields(signUpRequestJsonField)
                 ));
@@ -193,8 +193,7 @@ public class StoreControllerTest {
                 .andExpect(jsonPath("$.bname2").value(dto.getBname2()))
                 .andExpect(jsonPath("$.detailedAddress").value(dto.getDetailedAddress()))
                 .andExpect(jsonPath("$.categoryType").value(dto.getCategoryType().toString()))
-                .andExpect(jsonPath("$.tags[0]").value(dto.getTags().get(0)))
-                .andExpect(jsonPath("$.tags[1]").value(dto.getTags().get(1)))
+                .andExpect(jsonPath("$.tags[0]").exists())
                 .andDo(document("store/find",
                         requestParameters(
                                 parameterWithName("id").description("가게 아이디"),
@@ -225,7 +224,7 @@ public class StoreControllerTest {
                 .andExpect(jsonPath("$.name").value(updateDTO.getName().get()))
                 .andExpect(jsonPath("$.sido").value(updateDTO.getSido().get()))
                 .andExpect(jsonPath("$.categoryType").value(updateDTO.getCategoryType().get().toString()))
-                .andExpect(jsonPath("$.tags[0]").value(updateDTO.getTags().get(0)))
+                .andExpect(jsonPath("$.tags[0]").exists())
                 .andDo(document("store/update",
                         requestFields(updateRequestJsonField)
                 ));

--- a/src/test/java/com/dangol/dangolsonnimbackend/store/service/StoreServiceTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/store/service/StoreServiceTest.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import javax.transaction.Transactional;
+import java.util.List;
 import java.util.Random;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -51,6 +52,7 @@ public class StoreServiceTest {
                 .registerNumber("1234567890")
                 .registerName("단골손님")
                 .categoryType(CategoryType.KOREAN)
+                .tags(List.of("태그1", "태그2"))
                 .build();
 
         categoryRepository.saveAndFlush(new Category(CategoryType.KOREAN));


### PR DESCRIPTION
## Goals
- 태그 관련 서비스 로직을 추가한다.

## Implements
- [x] 요청과 응답 관련 DTO에 태그 필드 추가
- [x] 태그 엔티티와 가게 엔티티 간 다대다 매핑

## Related Issue 
- https://dangol-sonnim.atlassian.net/browse/DS-91

## Test
- "새로운 가게 정보 생성을 요청하면 정상적으로 생성이 된다."
- "특정 가게 아이디 값을 통해 가게를 검색할 수 있다."
- "특정 가게 정보를 업데이트하여 정보를 수정할 수 있다."