### PR TITLE
DS-95 [가게] 영업 시간 추가

### DIFF
--- a/src/main/java/com/dangol/dangolsonnimbackend/store/domain/BusinessHour.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/store/domain/BusinessHour.java
@@ -1,0 +1,35 @@
+package com.dangol.dangolsonnimbackend.store.domain;
+
+import com.dangol.dangolsonnimbackend.store.dto.BusinessHourRequestDTO;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@Table(name = "tb_business_hour")
+public class BusinessHour {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String weeks;
+    private String hours;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id", nullable = false)
+    @JsonIgnore
+    private Store store;
+
+    public BusinessHour(BusinessHourRequestDTO businessHourRequestDTO, Store store) {
+        this.hours = businessHourRequestDTO.getHours();
+        this.weeks = businessHourRequestDTO.getWeeks();
+        this.store = store;
+    }
+}

--- a/src/main/java/com/dangol/dangolsonnimbackend/store/domain/Store.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/store/domain/Store.java
@@ -54,9 +54,6 @@ public class Store {
     @Column(nullable = false)
     private String comments;
 
-    @Column(nullable = false)
-    private String officeHours;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "boss_id", nullable = false)
     @JsonIgnore
@@ -77,6 +74,10 @@ public class Store {
     @JsonIgnore
     @OneToMany(mappedBy = "store", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<Menu> menuList;
+
+    @JsonIgnore
+    @OneToMany(mappedBy = "store", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
+    private List<BusinessHour> businessHours;
   
     @ManyToMany
     @JoinTable(
@@ -88,6 +89,7 @@ public class Store {
     
     @Column
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("id asc")
     private List<Subscribe> subscribeList = new ArrayList<>();
 
     public Store(StoreSignupRequestDTO dto) {
@@ -100,7 +102,6 @@ public class Store {
         this.bname2 = dto.getBname2();
         this.detailedAddress = dto.getDetailedAddress();
         this.comments = dto.getComments();
-        this.officeHours = dto.getOfficeHours();
         this.registerName = dto.getRegisterName();
         this.registerNumber = dto.getRegisterNumber();
     }
@@ -133,7 +134,6 @@ public class Store {
         dto.getBname2().ifPresent(bname2 -> this.bname2 = bname2);
         dto.getDetailedAddress().ifPresent(detailedAddress -> this.detailedAddress = detailedAddress);
         dto.getComments().ifPresent(comments -> this.comments = comments);
-        dto.getOfficeHours().ifPresent(officeHours -> this.officeHours = officeHours);
         dto.getRegisterName().ifPresent(registerName -> this.registerName = registerName);
         category.ifPresent(newCategory -> updateCategory(newCategory));
 
@@ -141,7 +141,10 @@ public class Store {
     }
 
     public void setTags(Set<Tag> tags){
-        this.tags.clear();
         this.tags = tags;
+    }
+
+    public void setBusinessHours(List<BusinessHour> businessHours) {
+        this.businessHours = businessHours;
     }
 }

--- a/src/main/java/com/dangol/dangolsonnimbackend/store/dto/BusinessHourRequestDTO.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/store/dto/BusinessHourRequestDTO.java
@@ -1,0 +1,25 @@
+package com.dangol.dangolsonnimbackend.store.dto;
+
+import com.dangol.dangolsonnimbackend.store.domain.BusinessHour;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BusinessHourRequestDTO {
+    @NotNull(message = "영업 요일은 Null 일 수 없습니다")
+    private String weeks;
+    @NotNull(message = "영업 시간은 Null 일 수 없습니다")
+    private String hours;
+
+    public BusinessHourRequestDTO(BusinessHour businessHour){
+        this.weeks = businessHour.getWeeks();
+        this.hours = businessHour.getHours();
+    }
+}

--- a/src/main/java/com/dangol/dangolsonnimbackend/store/dto/StoreResponseDTO.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/store/dto/StoreResponseDTO.java
@@ -9,7 +9,6 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 @Getter
@@ -41,8 +40,7 @@ public class StoreResponseDTO {
 
     private CategoryType categoryType;
     private List<String> tags;
-
-    // TODO. 태그 및 이미지 필드 추가
+    private List<BusinessHourRequestDTO> businessHours;
 
     public StoreResponseDTO(Store store) {
         this.id = store.getId();
@@ -58,5 +56,7 @@ public class StoreResponseDTO {
         this.registerName = store.getRegisterName();
         this.categoryType = store.getCategory().getCategoryType();
         this.tags = store.getTags().stream().map(Tag::getName).collect(Collectors.toList());
+        this.businessHours = store.getBusinessHours().stream().map(BusinessHourRequestDTO::new)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/dangol/dangolsonnimbackend/store/dto/StoreSignupRequestDTO.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/store/dto/StoreSignupRequestDTO.java
@@ -36,9 +36,6 @@ public class StoreSignupRequestDTO {
     @NotNull(message = "한줄소개는 Null 일 수 없습니다.")
     private String comments;
 
-    @NotNull(message = "영업시간은 Null 일 수 없습니다.")
-    private String officeHours;
-
     @NotNull(message = "카테고리는 Null 일 수 없습니다.")
     private CategoryType categoryType;
 
@@ -48,6 +45,9 @@ public class StoreSignupRequestDTO {
     @NotNull(message = "사업자명은 Null 일 수 없습니다.")
     private String registerName;
 
+    @NotNull(message = "태그는 Null 일 수 없습니다.")
     private List<String> tags;
 
+    @NotNull(message = "영업시간은 Null 일 수 없습니다.")
+    private List<BusinessHourRequestDTO> businessHours;
 }

--- a/src/main/java/com/dangol/dangolsonnimbackend/store/dto/StoreUpdateDTO.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/store/dto/StoreUpdateDTO.java
@@ -31,8 +31,6 @@ public class StoreUpdateDTO {
 
     private Optional<String> comments = Optional.empty();
 
-    private Optional<String> officeHours = Optional.empty();
-
     @NotNull
     private String registerNumber;
 
@@ -41,6 +39,7 @@ public class StoreUpdateDTO {
     private Optional<CategoryType> categoryType = Optional.empty();
 
     private List<String> tags;
+    private List<BusinessHourRequestDTO> businessHours;
 
     private StoreUpdateDTO() { }
 
@@ -57,7 +56,6 @@ public class StoreUpdateDTO {
     public StoreUpdateDTO bname2(String bname2) { this.bname2 = Optional.of(bname2); return this; }
     public StoreUpdateDTO detailedAddress(String detailedAddress) { this.detailedAddress = Optional.of(detailedAddress); return this;}
     public StoreUpdateDTO comments(String comments) { this.comments = Optional.of(comments); return this; }
-    public StoreUpdateDTO officeHours(String officeHours) { this.officeHours = Optional.of(officeHours); return this; }
     public StoreUpdateDTO registerNumber(String registerNumber) { this.registerNumber = registerNumber; return this; }
     public StoreUpdateDTO registerName(String registerName) { this.registerName = Optional.of(registerName); return this; }
     public StoreUpdateDTO categoryType(CategoryType categoryType) { this.categoryType = Optional.of(categoryType); return this; }

--- a/src/main/java/com/dangol/dangolsonnimbackend/store/service/impl/StoreServiceImpl.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/store/service/impl/StoreServiceImpl.java
@@ -6,8 +6,10 @@ import com.dangol.dangolsonnimbackend.errors.BadRequestException;
 import com.dangol.dangolsonnimbackend.errors.InternalServerException;
 import com.dangol.dangolsonnimbackend.errors.NotFoundException;
 import com.dangol.dangolsonnimbackend.errors.enumeration.ErrorCodeMessage;
+import com.dangol.dangolsonnimbackend.store.domain.BusinessHour;
 import com.dangol.dangolsonnimbackend.store.domain.Category;
 import com.dangol.dangolsonnimbackend.store.domain.Store;
+import com.dangol.dangolsonnimbackend.store.dto.BusinessHourRequestDTO;
 import com.dangol.dangolsonnimbackend.store.dto.StoreResponseDTO;
 import com.dangol.dangolsonnimbackend.store.dto.StoreSignupRequestDTO;
 import com.dangol.dangolsonnimbackend.store.dto.StoreUpdateDTO;
@@ -20,6 +22,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -65,7 +69,14 @@ public class StoreServiceImpl implements StoreService {
         storeRepository.save(store);
 
         // 태그를 추가해주는 과정입니다.
-        store.setTags(tagService.getOrCreateTags(dto.getTags()));
+        store.setTags(tagService.getOrCreateTags(Optional.ofNullable(dto.getTags()).orElse(Collections.emptyList())));
+        // BusinessHour 생성
+        List<BusinessHour> businessHours = new ArrayList<>();
+        for (BusinessHourRequestDTO businessHourRequestDTO : dto.getBusinessHours()) {
+            BusinessHour businessHour = new BusinessHour(businessHourRequestDTO, store);
+            businessHours.add(businessHour);
+        }
+        store.setBusinessHours(businessHours);
 
         return new StoreResponseDTO(store);
     }
@@ -105,6 +116,15 @@ public class StoreServiceImpl implements StoreService {
 
         if (dto.getTags() != null && !dto.getTags().isEmpty()) {
             store.get().setTags(tagService.getOrCreateTags(dto.getTags()));
+        }
+
+        if (dto.getBusinessHours() != null && !dto.getBusinessHours().isEmpty()) {
+            List<BusinessHour> businessHours = new ArrayList<>();
+            for (BusinessHourRequestDTO businessHourRequestDTO : dto.getBusinessHours()) {
+                BusinessHour businessHour = new BusinessHour(businessHourRequestDTO, store.get());
+                businessHours.add(businessHour);
+            }
+            store.get().setBusinessHours(businessHours);
         }
 
         return store

--- a/src/test/java/com/dangol/dangolsonnimbackend/store/controller/MenuControllerTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/store/controller/MenuControllerTest.java
@@ -4,10 +4,7 @@ import com.amazonaws.util.IOUtils;
 import com.dangol.dangolsonnimbackend.boss.dto.request.BossSignupRequestDTO;
 import com.dangol.dangolsonnimbackend.boss.service.BossService;
 import com.dangol.dangolsonnimbackend.store.domain.Menu;
-import com.dangol.dangolsonnimbackend.store.dto.MenuRequestDTO;
-import com.dangol.dangolsonnimbackend.store.dto.MenuResponseDTO;
-import com.dangol.dangolsonnimbackend.store.dto.MenuUpdateRequestDTO;
-import com.dangol.dangolsonnimbackend.store.dto.StoreSignupRequestDTO;
+import com.dangol.dangolsonnimbackend.store.dto.*;
 import com.dangol.dangolsonnimbackend.store.enumeration.CategoryType;
 import com.dangol.dangolsonnimbackend.store.repository.MenuRepository;
 import com.dangol.dangolsonnimbackend.store.repository.dsl.MenuQueryRepository;
@@ -127,11 +124,12 @@ class MenuControllerTest {
                 .bname2("")
                 .detailedAddress("")
                 .comments("단골손님 가게로 좋아요.")
-                .officeHours("08:00~10:00")
                 .registerNumber("1234567890")
                 .registerName("단골손님")
                 .categoryType(CategoryType.KOREAN)
                 .tags(List.of("태그1", "태그2"))
+                .businessHours(List.of(new BusinessHourRequestDTO("월~수", "10:00~12:00"),
+                        new BusinessHourRequestDTO("토,일", "10:00~12:00")))
                 .build();
 
         return storeService.create(dto, BOSS_TEST_EMAIL).getId();

--- a/src/test/java/com/dangol/dangolsonnimbackend/store/controller/StoreControllerTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/store/controller/StoreControllerTest.java
@@ -5,6 +5,7 @@ import com.dangol.dangolsonnimbackend.boss.service.BossService;
 import com.dangol.dangolsonnimbackend.config.jwt.TokenProvider;
 import com.dangol.dangolsonnimbackend.errors.BadRequestException;
 import com.dangol.dangolsonnimbackend.store.domain.Category;
+import com.dangol.dangolsonnimbackend.store.dto.BusinessHourRequestDTO;
 import com.dangol.dangolsonnimbackend.store.dto.StoreSignupRequestDTO;
 import com.dangol.dangolsonnimbackend.store.dto.StoreUpdateDTO;
 import com.dangol.dangolsonnimbackend.store.enumeration.CategoryType;
@@ -92,11 +93,12 @@ public class StoreControllerTest {
             fieldWithPath("bname2").type(JsonFieldType.STRING).optional().description("가게 주소 (동/리)"),
             fieldWithPath("detailedAddress").type(JsonFieldType.STRING).optional().description("가게 상세주소"),
             fieldWithPath("comments").type(JsonFieldType.STRING).description("가게 한줄평"),
-            fieldWithPath("officeHours").type(JsonFieldType.STRING).description("가게 영업시간"),
             fieldWithPath("categoryType").type(JsonFieldType.VARIES).description("카테고리 정보"),
             fieldWithPath("registerNumber").type(JsonFieldType.STRING).description("가게 사업자번호"),
             fieldWithPath("registerName").type(JsonFieldType.STRING).description("가게 사업자명"),
-            fieldWithPath("tags").type(JsonFieldType.ARRAY).description("가게 태그")
+            fieldWithPath("tags").type(JsonFieldType.ARRAY).description("가게 태그"),
+            fieldWithPath("businessHours[].weeks").type(JsonFieldType.STRING).description("영업 요일"),
+            fieldWithPath("businessHours[].hours").type(JsonFieldType.STRING).description("영업 시간")
     };
 
     FieldDescriptor[] findResponseJsonField = new FieldDescriptor[] {
@@ -110,11 +112,12 @@ public class StoreControllerTest {
             fieldWithPath("bname1").type(JsonFieldType.STRING).description("가게 주소 (읍/면)"),
             fieldWithPath("bname2").type(JsonFieldType.STRING).description("가게 주소 (동/리)"),
             fieldWithPath("detailedAddress").type(JsonFieldType.STRING).description("가게 상세주소"),
-//            fieldWithPath("officeHours").type(JsonFieldType.STRING).description("가게 영업시간"),
             fieldWithPath("categoryType").type(JsonFieldType.VARIES).description("카테고리 정보"),
             fieldWithPath("registerNumber").type(JsonFieldType.STRING).description("가게 사업자번호"),
             fieldWithPath("registerName").type(JsonFieldType.STRING).description("가게 사업자명"),
-            fieldWithPath("tags").type(JsonFieldType.ARRAY).description("가게 태그")
+            fieldWithPath("tags").type(JsonFieldType.ARRAY).description("가게 태그"),
+            fieldWithPath("businessHours[].weeks").type(JsonFieldType.STRING).description("영업 요일"),
+            fieldWithPath("businessHours[].hours").type(JsonFieldType.STRING).description("영업 시간")
     };
 
     FieldDescriptor[] updateRequestJsonField = new FieldDescriptor[] {
@@ -127,11 +130,12 @@ public class StoreControllerTest {
             fieldWithPath("bname2").type(JsonFieldType.STRING).optional().description("가게 주소 (동/리)"),
             fieldWithPath("detailedAddress").type(JsonFieldType.STRING).optional().description("가게 상세주소"),
             fieldWithPath("comments").type(JsonFieldType.STRING).optional().description("가게 한줄평"),
-            fieldWithPath("officeHours").type(JsonFieldType.STRING).optional().description("가게 영업시간"),
             fieldWithPath("categoryType").type(JsonFieldType.VARIES).description("카테고리 정보"),
             fieldWithPath("registerNumber").type(JsonFieldType.STRING).description("가게 사업자번호"),
             fieldWithPath("registerName").type(JsonFieldType.STRING).optional().description("가게 사업자명"),
-            fieldWithPath("tags").type(JsonFieldType.ARRAY).description("가게 태그")
+            fieldWithPath("tags").type(JsonFieldType.ARRAY).description("가게 태그"),
+            fieldWithPath("businessHours[].weeks").type(JsonFieldType.STRING).description("영업 요일"),
+            fieldWithPath("businessHours[].hours").type(JsonFieldType.STRING).description("영업 시간")
     };
 
     @BeforeEach
@@ -154,11 +158,12 @@ public class StoreControllerTest {
                 .bname2("")
                 .detailedAddress("")
                 .comments("단골손님 가게로 좋아요.")
-                .officeHours("08:00~10:00")
                 .categoryType(CategoryType.KOREAN)
                 .registerNumber("1234567890")
                 .registerName("단골손님")
                 .tags(List.of("태그1", "태그2"))
+                .businessHours(List.of(new BusinessHourRequestDTO("월~수", "10:00~12:00"),
+                        new BusinessHourRequestDTO("토,일", "10:00~12:00")))
                 .build();
 
         BossSignupRequestDTO bossSignupRequestDTO = new BossSignupRequestDTO();
@@ -195,6 +200,10 @@ public class StoreControllerTest {
                 .andExpect(jsonPath("$.categoryType").value(dto.getCategoryType().toString()))
                 .andExpect(jsonPath("$.tags[0]").exists())
                 .andExpect(jsonPath("$.tags[1]").exists())
+                .andExpect(jsonPath("$.businessHours[0].weeks").value(dto.getBusinessHours().get(0).getWeeks()))
+                .andExpect(jsonPath("$.businessHours[0].hours").value(dto.getBusinessHours().get(0).getHours()))
+                .andExpect(jsonPath("$.businessHours[1].weeks").value(dto.getBusinessHours().get(1).getWeeks()))
+                .andExpect(jsonPath("$.businessHours[1].hours").value(dto.getBusinessHours().get(1).getHours()))
                 .andDo(document("store/create",
                         requestHeaders(headerWithName("Authorization").description("Access 토큰 정보")),
                         requestFields(signUpRequestJsonField)
@@ -223,6 +232,10 @@ public class StoreControllerTest {
                 .andExpect(jsonPath("$.detailedAddress").value(dto.getDetailedAddress()))
                 .andExpect(jsonPath("$.categoryType").value(dto.getCategoryType().toString()))
                 .andExpect(jsonPath("$.tags[0]").exists())
+                .andExpect(jsonPath("$.businessHours[0].weeks").value(dto.getBusinessHours().get(0).getWeeks()))
+                .andExpect(jsonPath("$.businessHours[0].hours").value(dto.getBusinessHours().get(0).getHours()))
+                .andExpect(jsonPath("$.businessHours[1].weeks").value(dto.getBusinessHours().get(1).getWeeks()))
+                .andExpect(jsonPath("$.businessHours[1].hours").value(dto.getBusinessHours().get(1).getHours()))
                 .andDo(document("store/find",
                         requestParameters(
                                 parameterWithName("id").description("가게 아이디"),
@@ -248,6 +261,7 @@ public class StoreControllerTest {
         updateDTO.setSido(Optional.of("경기도"));
         updateDTO.setCategoryType(Optional.of(CategoryType.CHINESE));
         updateDTO.setTags(List.of("변경 태그1"));
+        updateDTO.setBusinessHours(List.of(new BusinessHourRequestDTO("수~목", "11:00~12:00")));
 
         mockMvc.perform(patch("/api/v1/store/update")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -258,6 +272,8 @@ public class StoreControllerTest {
                 .andExpect(jsonPath("$.sido").value(updateDTO.getSido().get()))
                 .andExpect(jsonPath("$.categoryType").value(updateDTO.getCategoryType().get().toString()))
                 .andExpect(jsonPath("$.tags[0]").exists())
+                .andExpect(jsonPath("$.businessHours[0].weeks").value(updateDTO.getBusinessHours().get(0).getWeeks()))
+                .andExpect(jsonPath("$.businessHours[0].hours").value(updateDTO.getBusinessHours().get(0).getHours()))
                 .andDo(document("store/update",
                         requestFields(updateRequestJsonField)
                 ));
@@ -299,6 +315,10 @@ public class StoreControllerTest {
                 .andExpect(jsonPath("$[0].detailedAddress").value(dto.getDetailedAddress()))
                 .andExpect(jsonPath("$[0].categoryType").value(dto.getCategoryType().toString()))
                 .andExpect(jsonPath("$[0].tags[0]").exists())
+                .andExpect(jsonPath("$[0].businessHours[0].weeks").value(dto.getBusinessHours().get(0).getWeeks()))
+                .andExpect(jsonPath("$[0].businessHours[0].hours").value(dto.getBusinessHours().get(0).getHours()))
+                .andExpect(jsonPath("$[0].businessHours[1].weeks").value(dto.getBusinessHours().get(1).getWeeks()))
+                .andExpect(jsonPath("$[0].businessHours[1].hours").value(dto.getBusinessHours().get(1).getHours()))
                 .andDo(document("store/my-store",
                         requestHeaders(headerWithName("Authorization").description("Access 토큰 정보")),
                         responseFields(
@@ -314,7 +334,9 @@ public class StoreControllerTest {
                                 fieldWithPath("[].categoryType").type(JsonFieldType.VARIES).description("카테고리 정보"),
                                 fieldWithPath("[].registerNumber").type(JsonFieldType.STRING).description("가게 사업자번호"),
                                 fieldWithPath("[].registerName").type(JsonFieldType.STRING).description("가게 사업자명"),
-                                fieldWithPath("[].tags").type(JsonFieldType.ARRAY).description("가게 태그")
+                                fieldWithPath("[].tags").type(JsonFieldType.ARRAY).description("가게 태그"),
+                                fieldWithPath("[].businessHours[].weeks").type(JsonFieldType.STRING).description("영업 요일"),
+                                fieldWithPath("[].businessHours[].hours").type(JsonFieldType.STRING).description("영업 시간")
                         )
                 ));
     }

--- a/src/test/java/com/dangol/dangolsonnimbackend/store/domain/StoreTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/store/domain/StoreTest.java
@@ -1,8 +1,11 @@
 package com.dangol.dangolsonnimbackend.store.domain;
 
+import com.dangol.dangolsonnimbackend.store.dto.BusinessHourRequestDTO;
 import com.dangol.dangolsonnimbackend.store.dto.StoreSignupRequestDTO;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -20,9 +23,10 @@ public class StoreTest {
                 .bname1("단골동")
                 .detailedAddress("")
                 .comments("단골손님 가게로 좋아요.")
-                .officeHours("08:00~10:00")
                 .registerNumber("123-456-789")
                 .registerName("단골손님")
+                .businessHours(List.of(new BusinessHourRequestDTO("월~수", "10:00~12:00"),
+                        new BusinessHourRequestDTO("토,일", "10:00~12:00")))
                 .build();
 
         Store store = new Store(dto);

--- a/src/test/java/com/dangol/dangolsonnimbackend/store/repository/CategoryRepositoryTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/store/repository/CategoryRepositoryTest.java
@@ -5,9 +5,9 @@ import com.dangol.dangolsonnimbackend.boss.dto.request.BossSignupRequestDTO;
 import com.dangol.dangolsonnimbackend.boss.service.BossService;
 import com.dangol.dangolsonnimbackend.store.domain.Category;
 import com.dangol.dangolsonnimbackend.store.domain.Store;
+import com.dangol.dangolsonnimbackend.store.dto.BusinessHourRequestDTO;
 import com.dangol.dangolsonnimbackend.store.dto.StoreSignupRequestDTO;
 import com.dangol.dangolsonnimbackend.store.enumeration.CategoryType;
-import com.dangol.dangolsonnimbackend.store.service.StoreService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -58,11 +58,12 @@ class CategoryRepositoryTest {
                 .bname2("")
                 .detailedAddress("")
                 .comments("단골손님 가게로 좋아요.")
-                .officeHours("08:00~10:00")
                 .categoryType(CategoryType.KOREAN)
                 .registerNumber("1234567890")
                 .registerName("단골손님")
                 .tags(List.of("태그1", "태그2"))
+                .businessHours(List.of(new BusinessHourRequestDTO("월~수", "10:00~12:00"),
+                        new BusinessHourRequestDTO("토,일", "10:00~12:00")))
                 .build();
 
         category = new Category();

--- a/src/test/java/com/dangol/dangolsonnimbackend/store/repository/StoreRepositoryTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/store/repository/StoreRepositoryTest.java
@@ -5,6 +5,7 @@ import com.dangol.dangolsonnimbackend.boss.dto.request.BossSignupRequestDTO;
 import com.dangol.dangolsonnimbackend.boss.service.BossService;
 import com.dangol.dangolsonnimbackend.store.domain.Category;
 import com.dangol.dangolsonnimbackend.store.domain.Store;
+import com.dangol.dangolsonnimbackend.store.dto.BusinessHourRequestDTO;
 import com.dangol.dangolsonnimbackend.store.dto.StoreSignupRequestDTO;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -15,7 +16,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import javax.transaction.Transactional;
 import java.util.List;
 import java.util.Optional;
-import java.util.Random;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
@@ -59,10 +59,11 @@ class StoreRepositoryTest {
                 .bname1("단골동")
                 .detailedAddress("")
                 .comments("단골손님 가게로 좋아요.")
-                .officeHours("08:00~10:00")
                 .registerNumber("123-456-789")
                 .registerName("단골손님")
                 .tags(List.of("태그1", "태그2"))
+                .businessHours(List.of(new BusinessHourRequestDTO("월~수", "10:00~12:00"),
+                        new BusinessHourRequestDTO("토,일", "10:00~12:00")))
                 .build();
         Category category = new Category();
         category.setCategoryType(dto.getCategoryType());

--- a/src/test/java/com/dangol/dangolsonnimbackend/store/repository/dsl/StoreQueryRepositoryTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/store/repository/dsl/StoreQueryRepositoryTest.java
@@ -5,6 +5,7 @@ import com.dangol.dangolsonnimbackend.boss.dto.request.BossSignupRequestDTO;
 import com.dangol.dangolsonnimbackend.boss.service.BossService;
 import com.dangol.dangolsonnimbackend.store.domain.Category;
 import com.dangol.dangolsonnimbackend.store.domain.Store;
+import com.dangol.dangolsonnimbackend.store.dto.BusinessHourRequestDTO;
 import com.dangol.dangolsonnimbackend.store.dto.StoreSignupRequestDTO;
 import com.dangol.dangolsonnimbackend.store.repository.CategoryRepository;
 import com.dangol.dangolsonnimbackend.store.repository.StoreRepository;
@@ -16,7 +17,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import javax.transaction.Transactional;
 import java.util.List;
-import java.util.Random;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -62,10 +62,11 @@ class StoreQueryRepositoryTest {
                 .bname1("단골동")
                 .detailedAddress("")
                 .comments("단골손님 가게로 좋아요.")
-                .officeHours("08:00~10:00")
                 .registerNumber("123-456-789")
                 .registerName("단골손님")
                 .tags(List.of("태그1", "태그2"))
+                .businessHours(List.of(new BusinessHourRequestDTO("월~수", "10:00~12:00"),
+                        new BusinessHourRequestDTO("토,일", "10:00~12:00")))
                 .build();
         Category category = new Category();
         category.setCategoryType(dto.getCategoryType());

--- a/src/test/java/com/dangol/dangolsonnimbackend/store/service/StoreServiceTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/store/service/StoreServiceTest.java
@@ -1,15 +1,14 @@
 package com.dangol.dangolsonnimbackend.store.service;
 
-import com.dangol.dangolsonnimbackend.boss.domain.Boss;
 import com.dangol.dangolsonnimbackend.boss.dto.request.BossSignupRequestDTO;
 import com.dangol.dangolsonnimbackend.boss.service.BossService;
 import com.dangol.dangolsonnimbackend.store.domain.Category;
+import com.dangol.dangolsonnimbackend.store.dto.BusinessHourRequestDTO;
 import com.dangol.dangolsonnimbackend.store.dto.StoreResponseDTO;
 import com.dangol.dangolsonnimbackend.store.dto.StoreSignupRequestDTO;
 import com.dangol.dangolsonnimbackend.store.dto.StoreUpdateDTO;
 import com.dangol.dangolsonnimbackend.store.enumeration.CategoryType;
 import com.dangol.dangolsonnimbackend.store.repository.CategoryRepository;
-import com.dangol.dangolsonnimbackend.store.repository.StoreRepository;
 import com.dangol.dangolsonnimbackend.store.repository.dsl.StoreQueryRepository;
 import com.dangol.dangolsonnimbackend.store.service.impl.StoreServiceImpl;
 import org.junit.jupiter.api.BeforeEach;
@@ -58,11 +57,12 @@ public class StoreServiceTest {
                 .bname2("")
                 .detailedAddress("")
                 .comments("단골손님 가게로 좋아요.")
-                .officeHours("08:00~10:00")
                 .registerNumber("1234567890")
                 .registerName("단골손님")
                 .categoryType(CategoryType.KOREAN)
                 .tags(List.of("태그1", "태그2"))
+                .businessHours(List.of(new BusinessHourRequestDTO("월~수", "10:00~12:00"),
+                        new BusinessHourRequestDTO("토,일", "10:00~12:00")))
                 .build();
 
         BossSignupRequestDTO bossSignupRequestDTO = new BossSignupRequestDTO();

--- a/src/test/java/com/dangol/dangolsonnimbackend/subscribe/controller/SubscribeControllerTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/subscribe/controller/SubscribeControllerTest.java
@@ -2,7 +2,7 @@ package com.dangol.dangolsonnimbackend.subscribe.controller;
 
 import com.dangol.dangolsonnimbackend.boss.dto.request.BossSignupRequestDTO;
 import com.dangol.dangolsonnimbackend.boss.service.BossService;
-import com.dangol.dangolsonnimbackend.store.domain.Category;
+import com.dangol.dangolsonnimbackend.store.dto.BusinessHourRequestDTO;
 import com.dangol.dangolsonnimbackend.store.dto.StoreSignupRequestDTO;
 import com.dangol.dangolsonnimbackend.store.enumeration.CategoryType;
 import com.dangol.dangolsonnimbackend.store.repository.CategoryRepository;
@@ -95,11 +95,12 @@ class SubscribeControllerTest {
                 .bname2("")
                 .detailedAddress("")
                 .comments("단골손님 가게로 좋아요.")
-                .officeHours("08:00~10:00")
                 .registerNumber("1234567890")
                 .registerName("단골손님")
                 .categoryType(CategoryType.KOREAN)
                 .tags(List.of("태그1", "태그2"))
+                .businessHours(List.of(new BusinessHourRequestDTO("월~수", "10:00~12:00"),
+                        new BusinessHourRequestDTO("토,일", "10:00~12:00")))
                 .build();
 
         List<BenefitDTO> benefitDTOList = List.of(

--- a/src/test/java/com/dangol/dangolsonnimbackend/subscribe/repository/CountSubscribeRepositoryTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/subscribe/repository/CountSubscribeRepositoryTest.java
@@ -5,6 +5,7 @@ import com.dangol.dangolsonnimbackend.boss.dto.request.BossSignupRequestDTO;
 import com.dangol.dangolsonnimbackend.boss.service.BossService;
 import com.dangol.dangolsonnimbackend.store.domain.Category;
 import com.dangol.dangolsonnimbackend.store.domain.Store;
+import com.dangol.dangolsonnimbackend.store.dto.BusinessHourRequestDTO;
 import com.dangol.dangolsonnimbackend.store.dto.StoreSignupRequestDTO;
 import com.dangol.dangolsonnimbackend.store.repository.CategoryRepository;
 import com.dangol.dangolsonnimbackend.store.repository.StoreRepository;
@@ -58,10 +59,11 @@ class CountSubscribeRepositoryTest {
                 .bname1("단골동")
                 .detailedAddress("")
                 .comments("단골손님 가게로 좋아요.")
-                .officeHours("08:00~10:00")
                 .registerNumber("123-456-789")
                 .registerName("단골손님")
                 .tags(List.of("태그1", "태그2"))
+                .businessHours(List.of(new BusinessHourRequestDTO("월~수", "10:00~12:00"),
+                        new BusinessHourRequestDTO("토,일", "10:00~12:00")))
                 .build();
         Category category = new Category();
         category.setCategoryType(dto.getCategoryType());

--- a/src/test/java/com/dangol/dangolsonnimbackend/subscribe/repository/MonthlySubscribeRepositoryTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/subscribe/repository/MonthlySubscribeRepositoryTest.java
@@ -5,10 +5,10 @@ import com.dangol.dangolsonnimbackend.boss.dto.request.BossSignupRequestDTO;
 import com.dangol.dangolsonnimbackend.boss.service.BossService;
 import com.dangol.dangolsonnimbackend.store.domain.Category;
 import com.dangol.dangolsonnimbackend.store.domain.Store;
+import com.dangol.dangolsonnimbackend.store.dto.BusinessHourRequestDTO;
 import com.dangol.dangolsonnimbackend.store.dto.StoreSignupRequestDTO;
 import com.dangol.dangolsonnimbackend.store.repository.CategoryRepository;
 import com.dangol.dangolsonnimbackend.store.repository.StoreRepository;
-import com.dangol.dangolsonnimbackend.subscribe.domain.CountSubscribe;
 import com.dangol.dangolsonnimbackend.subscribe.domain.MonthlySubscribe;
 import com.dangol.dangolsonnimbackend.subscribe.dto.SubscribeRequestDTO;
 import org.junit.jupiter.api.Test;
@@ -60,10 +60,11 @@ class MonthlySubscribeRepositoryTest {
                 .bname1("단골동")
                 .detailedAddress("")
                 .comments("단골손님 가게로 좋아요.")
-                .officeHours("08:00~10:00")
                 .registerNumber("123-456-789")
                 .registerName("단골손님")
                 .tags(List.of("태그1", "태그2"))
+                .businessHours(List.of(new BusinessHourRequestDTO("월~수", "10:00~12:00"),
+                        new BusinessHourRequestDTO("토,일", "10:00~12:00")))
                 .build();
         Category category = new Category();
         category.setCategoryType(dto.getCategoryType());

--- a/src/test/java/com/dangol/dangolsonnimbackend/subscribe/service/impl/SubscribeServiceImplTest.java
+++ b/src/test/java/com/dangol/dangolsonnimbackend/subscribe/service/impl/SubscribeServiceImplTest.java
@@ -7,8 +7,8 @@ import com.dangol.dangolsonnimbackend.errors.NotFoundException;
 import com.dangol.dangolsonnimbackend.errors.enumeration.ErrorCodeMessage;
 import com.dangol.dangolsonnimbackend.store.domain.Category;
 import com.dangol.dangolsonnimbackend.store.domain.Store;
+import com.dangol.dangolsonnimbackend.store.dto.BusinessHourRequestDTO;
 import com.dangol.dangolsonnimbackend.store.dto.StoreSignupRequestDTO;
-import com.dangol.dangolsonnimbackend.store.enumeration.CategoryType;
 import com.dangol.dangolsonnimbackend.store.repository.CategoryRepository;
 import com.dangol.dangolsonnimbackend.store.repository.StoreRepository;
 import com.dangol.dangolsonnimbackend.subscribe.domain.CountSubscribe;
@@ -29,7 +29,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
-import java.util.Random;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -76,10 +75,11 @@ class SubscribeServiceImplTest {
                 .bname1("단골동")
                 .detailedAddress("")
                 .comments("단골손님 가게로 좋아요.")
-                .officeHours("08:00~10:00")
                 .registerNumber("123-456-789")
                 .registerName("단골손님")
                 .tags(List.of("태그1", "태그2"))
+                .businessHours(List.of(new BusinessHourRequestDTO("월~수", "10:00~12:00"),
+                        new BusinessHourRequestDTO("토,일", "10:00~12:00")))
                 .build();
 
         Category category = new Category();


### PR DESCRIPTION
## Goals
- 가게에 영업시간을 받도록 추가 구현합니다.
- 영업시간은 배열의 형태로 다수 존재하므로 가게와 영업시간을 일대 다 매핑으로 조절

## Implements
- [x] 가게 생성 API 에 영업시간을 추가하도록 구현
- [x] 영업시간과 관련된 모든 가게 API 수정
- [x] 영업시간과 관련된 DTO 추가

## Related Issue 
- https://dangol-sonnim.atlassian.net/browse/DS-95

## Test
- "가게를 성공적으로 생성한다."
- "가게를 성공적으로 삭제한다."
- "가게를 성공적으로 조회한다."
- "가게를 성공적으로 수정한다."
- "나의 가게를 성공적으로 조회한다."

