### PR TITLE
DS-97 [가게] 가게 상세보기 수정

### DIFF
--- a/src/docs/asciidoc/dangol-backend-api-guide.adoc
+++ b/src/docs/asciidoc/dangol-backend-api-guide.adoc
@@ -196,7 +196,7 @@ include::{snippets}/store/create/request-fields.adoc[]
 include::{snippets}/store/create/http-response.adoc[]
 
 ==== 2. 가게 조회
-현재 가게 정보를 조회합니다.
+가게 정보를 상세 조회합니다.
 
 - Request
 include::{snippets}/store/find/http-request.adoc[]

--- a/src/main/java/com/dangol/dangolsonnimbackend/store/controller/StoreController.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/store/controller/StoreController.java
@@ -39,9 +39,9 @@ public class StoreController {
                 .body(res);
     }
 
-    @GetMapping("/find")
-    public ResponseEntity<StoreResponseDTO> findById(@RequestParam Map<String, String> params) {
-        StoreResponseDTO res = storeService.findById(Long.valueOf(params.get("id")));
+    @GetMapping("/find/{storeId}")
+    public ResponseEntity<StoreDetailResponseDTO> findById(@PathVariable Long storeId) {
+        StoreDetailResponseDTO res = storeService.findById(storeId);
 
         return ResponseEntity
                 .status(HttpStatus.OK)

--- a/src/main/java/com/dangol/dangolsonnimbackend/store/domain/Store.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/store/domain/Store.java
@@ -72,8 +72,8 @@ public class Store {
     private String registerName;
 
     @JsonIgnore
-    @OneToMany(mappedBy = "store", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    private List<Menu> menuList;
+    @OneToMany(mappedBy = "store", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
+    private List<Menu> menuList = new ArrayList<>();
 
     @JsonIgnore
     @OneToMany(mappedBy = "store", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
@@ -88,12 +88,12 @@ public class Store {
     private Set<Tag> tags = new HashSet<>();
     
     @Column
-    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
     @OrderBy("id asc")
     private List<Subscribe> subscribeList = new ArrayList<>();
 
     @Column
-    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     @OrderBy("id asc")
     private List<StoreImage> storeImages = new ArrayList<>();
 

--- a/src/main/java/com/dangol/dangolsonnimbackend/store/dto/StoreDetailResponseDTO.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/store/dto/StoreDetailResponseDTO.java
@@ -1,0 +1,84 @@
+package com.dangol.dangolsonnimbackend.store.dto;
+
+import com.dangol.dangolsonnimbackend.errors.InternalServerException;
+import com.dangol.dangolsonnimbackend.errors.enumeration.ErrorCodeMessage;
+import com.dangol.dangolsonnimbackend.store.domain.Store;
+import com.dangol.dangolsonnimbackend.store.domain.StoreImage;
+import com.dangol.dangolsonnimbackend.store.domain.Tag;
+import com.dangol.dangolsonnimbackend.store.enumeration.CategoryType;
+import com.dangol.dangolsonnimbackend.subscribe.domain.CountSubscribe;
+import com.dangol.dangolsonnimbackend.subscribe.domain.MonthlySubscribe;
+import com.dangol.dangolsonnimbackend.subscribe.dto.SubscribeResponseDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class StoreDetailResponseDTO {
+    private Long id;
+
+    private String name;
+
+    private String newAddress;
+
+    private String comments;
+
+    private String sido;
+
+    private String sigungu;
+
+    private String bname1;
+
+    private String bname2;
+
+    private String detailedAddress;
+
+    private String registerNumber;
+
+    private String registerName;
+
+    private CategoryType categoryType;
+    private List<String> tags;
+    private List<BusinessHourRequestDTO> businessHours;
+    private List<MenuResponseDTO> menuResponseDTOList;
+    private List<SubscribeResponseDTO> subscribeResponseDTOList;
+    private List<String> storeImageUrlList;
+
+    public StoreDetailResponseDTO(Store store) {
+        this.id = store.getId();
+        this.name = store.getName();
+        this.newAddress = store.getNewAddress();
+        this.comments = store.getComments();
+        this.sido = store.getSido();
+        this.sigungu = store.getSigungu();
+        this.bname1 = store.getBname1();
+        this.bname2 = store.getBname2();
+        this.detailedAddress = store.getDetailedAddress();
+        this.registerNumber = store.getRegisterNumber();
+        this.registerName = store.getRegisterName();
+        this.categoryType = store.getCategory().getCategoryType();
+        this.tags = store.getTags().stream().map(Tag::getName).collect(Collectors.toList());
+        this.businessHours = store.getBusinessHours().stream().map(BusinessHourRequestDTO::new)
+                .collect(Collectors.toList());
+        this.menuResponseDTOList = store.getMenuList().stream().map(MenuResponseDTO::new)
+                .collect(Collectors.toList());
+        this.subscribeResponseDTOList = store.getSubscribeList().stream().map(subscribe -> {
+            if (subscribe instanceof CountSubscribe) {
+                return new SubscribeResponseDTO((CountSubscribe) subscribe);
+            } else if (subscribe instanceof MonthlySubscribe) {
+                return new SubscribeResponseDTO((MonthlySubscribe) subscribe);
+            } else {
+                throw new InternalServerException(ErrorCodeMessage.INVALID_SUBSCRIBE_TYPE);
+            }
+        }).collect(Collectors.toList());
+        this.storeImageUrlList = store.getStoreImages().stream().map(StoreImage::getImageUrl)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/dangol/dangolsonnimbackend/store/service/StoreService.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/store/service/StoreService.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public interface StoreService {
     StoreResponseDTO create(StoreSignupRequestDTO dto, String email);
-    StoreResponseDTO findById(Long id);
+    StoreDetailResponseDTO findById(Long id);
     StoreResponseDTO updateStoreByDto(StoreUpdateDTO dto);
 
     List<StoreResponseDTO> findMyStore(String email);

--- a/src/main/java/com/dangol/dangolsonnimbackend/store/service/impl/MenuServiceImpl.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/store/service/impl/MenuServiceImpl.java
@@ -40,7 +40,9 @@ public class MenuServiceImpl implements MenuService {
                 () -> new NotFoundException(ErrorCodeMessage.STORE_NOT_FOUND)
         );
         String s3FileUrl = uploadFileIfPresent(dto.getMultipartFile());
-        return new MenuResponseDTO(menuRepository.save(new Menu(dto.getName(), s3FileUrl, store, dto.getPrice())));
+        Menu menu = menuRepository.save(new Menu(dto.getName(), s3FileUrl, store, dto.getPrice()));
+        store.getMenuList().add(menu);
+        return new MenuResponseDTO(menu);
     }
 
     @Override

--- a/src/main/java/com/dangol/dangolsonnimbackend/store/service/impl/MenuServiceImpl.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/store/service/impl/MenuServiceImpl.java
@@ -69,6 +69,10 @@ public class MenuServiceImpl implements MenuService {
 
     @Override
     public void delete(Long menuId) {
+        Menu menu = menuQueryRepository.findById(menuId).orElseThrow(
+                () -> new NotFoundException(ErrorCodeMessage.MENU_NOT_FOUND)
+        );
+        menu.getStore().getMenuList().remove(menu);
         menuRepository.deleteById(menuId);
     }
 

--- a/src/main/java/com/dangol/dangolsonnimbackend/store/service/impl/StoreServiceImpl.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/store/service/impl/StoreServiceImpl.java
@@ -90,14 +90,12 @@ public class StoreServiceImpl implements StoreService {
      * @return 변경된 정보
      */
     @Override
-    public StoreResponseDTO findById(Long id) {
-        Optional<Store> store = storeQueryRepository.findById(id);
+    public StoreDetailResponseDTO findById(Long id) {
+        Store store = storeQueryRepository.findById(id).orElseThrow(
+                () -> new BadRequestException(ErrorCodeMessage.STORE_NOT_FOUND)
+        );
 
-        if(store.isEmpty())
-            throw new BadRequestException(ErrorCodeMessage.STORE_NOT_FOUND);
-
-        return store.map(StoreResponseDTO::new)
-                .orElseThrow(() -> new InternalServerException(ErrorCodeMessage.RESPONSE_CREATE_ERROR));
+        return new StoreDetailResponseDTO(store);
     }
 
     /**

--- a/src/main/java/com/dangol/dangolsonnimbackend/subscribe/service/impl/SubscribeServiceImpl.java
+++ b/src/main/java/com/dangol/dangolsonnimbackend/subscribe/service/impl/SubscribeServiceImpl.java
@@ -70,6 +70,9 @@ public class SubscribeServiceImpl implements SubscribeService {
 
     @Transactional
     public void deleteSubscribe(Long subscribeId) {
+        Subscribe subscribe = subscribeRepository.findById(subscribeId).orElseThrow(
+                () -> new NotFoundException(ErrorCodeMessage.SUBSCRIBE_NOT_FOUND));
+        subscribe.getStore().getSubscribeList().remove(subscribe);
         subscribeRepository.deleteById(subscribeId);
     }
 }


### PR DESCRIPTION
## Goals
- 가게 상세 조회 API 를 수정합니다 (메뉴와 구독권 까지 조회되도록 변경)

## Implements
- [x] 기존 가게 찾기 로직 변경

## Related Issue 
- https://dangol-sonnim.atlassian.net/browse/DS-97

## Test
- "가게를 성공적으로 조회한다."
